### PR TITLE
巻11の校訂注入力（1条～10条1項まで）

### DIFF
--- a/TEI files/engishiki_v11.xml
+++ b/TEI files/engishiki_v11.xml
@@ -46,42 +46,85 @@
 <p ana="項" corresp="engishiki_ja.xml#item11100101 engishiki_en.xml#item11100101" xml:id="item11100101">
 <anchor xml:id="app1110010101"/><anchor xml:id="app1110010101e"/>
                         凡内外諸司所申庶務、弁官惣勘申太政官、其史読申、皆依司次、若申数事、各先神事、申神事史不申凶事、御本命日〈中宮・東宮亦同、〉及朔日・重日・復日亦不申凶事、<lb/></p>
+                        <app from="#app1110010101" to="#app1110010101e">
+                                                <lem wit="#土本">弘</lem>
+                        </app>
 </div>
 <div ana="太政官" n="11.2" subtype="項" type="条">
 <head ana="庶務申官"/>
 <p ana="項" corresp="engishiki_ja.xml#item11100201 engishiki_en.xml#item11100201" xml:id="item11100201">
 <anchor xml:id="app1110020101"/><anchor xml:id="app1110020101e"/>
                         凡庶務申太政官、若大臣不在者、申中納言以上、其事<anchor xml:id="app1110020102"/>重<anchor xml:id="app1110020102e"/>者臨時奏裁、自余准例処分、其考選目録及請印六位以下位記者、中務・式部・兵部三省不経弁官直申太政官、中務申夏冬時服、及式部補文学・家令以下傔仗簡<anchor xml:id="app1110020103"/>遣諸国使人<anchor xml:id="app1110020103e"/>亦直申、<lb/></p>
+                        <app from="#app1110020101" to="#app1110020101e">
+                                                <lem wit="#近本 #壬本 #等">弘</lem>
+                                                <rdg wit="#土本"/>
+                                                <note>弘　土本無し。近本・壬本等により補う。</note>
+                        </app>
+                        <app from="#app1110020102" to="#app1110020102e">
+                                                <lem wit="#近本 #壬本 #等">重</lem>
+                                                <rdg wit="#土本"/>
+                                                <note>重　土本無し。近本・壬本等により補う。</note>
+                        </app>
+                        <app from="#app1110020103" to="#app1110020103e">
+                                                <lem>遣諸国使人</lem>
+                                                <rdg wit="#土本 #諸本"/>
+                                                <note>遣諸国使人　諸本なし。類聚符宣抄第六外記職掌所収延喜七年七月十七日宣旨所引「先式」により補う。</note>
+                        </app>
 </div>
 <div ana="太政官" n="11.3" subtype="項" type="条">
 <head ana="申政"/>
 <p ana="項" corresp="engishiki_ja.xml#item11100301 engishiki_en.xml#item11100301" xml:id="item11100301">
 <anchor xml:id="app1110030101"/><anchor xml:id="app1110030101e"/>
                         凡諸司申政於太政官者、先経外記、然後令申、<lb/></p>
+                        <app from="#app1110030101" to="#app1110030101e">
+                                                <lem wit="#土本">延</lem>
+                        </app>
 </div>
 <div ana="太政官" n="11.4" subtype="項" type="条">
 <head ana="時刻"/>
 <p ana="項" corresp="engishiki_ja.xml#item11100401 engishiki_en.xml#item11100401" xml:id="item11100401">
 <anchor xml:id="app1110040101"/><anchor xml:id="app1110040101e"/>
                         凡弁官申政時刻、自三月至七月辰三刻、自九月至正月已<anchor xml:id="app1110040102"/>二<anchor xml:id="app1110040102e"/>刻、二・八両月已一刻、<lb/></p>
+                        <app from="#app1110040101" to="#app1110040101e">
+                                                <lem>貞</lem>
+                        </app>
+                        <app from="#app1110040102" to="#app1110040102e">
+                                                <lem wit="#近本訂正書 #等">二</lem>
+                                                <rdg wit="#土本"/>
+                                                <note>二　土本無し。近本訂正書等により補う。</note>
+                        </app>
 </div>
 <div ana="太政官" n="11.5" subtype="項" type="条">
 <head ana="朝堂政"/>
 <p ana="項" corresp="engishiki_ja.xml#item11100501 engishiki_en.xml#item11100501" xml:id="item11100501">
 <anchor xml:id="app1110050101"/><anchor xml:id="app1110050101e"/>
                         凡百官庶政、皆於朝堂行之、但三月・十月、旬日着之、正月・二月・十一月・十二月、並在曹司行之、<lb/></p>
+                        <app from="#app1110050101" to="#app1110050101e">
+                                                <lem wit="#土本">弘</lem>
+                        </app>
 </div>
 <div ana="太政官" n="11.6" subtype="項" type="条">
 <head ana="諸司諸国申政"/>
 <p ana="項" corresp="engishiki_ja.xml#item11100601 engishiki_en.xml#item11100601" xml:id="item11100601">
 <anchor xml:id="app1110060101"/><anchor xml:id="app1110060101e"/>
                         凡諸司・諸国申政之時、史読申已訖、弁判曰、云云、畢即史仰云、縦、〈読曰与志、〉<lb/></p>
+                        <app from="#app1110060101" to="#app1110060101e">
+                                                <lem wit="#土本">延</lem>
+                        </app>
 </div>
 <div ana="太政官" n="11.7" subtype="項" type="条">
 <head ana="受事"/>
 <p ana="項" corresp="engishiki_ja.xml#item11100701 engishiki_en.xml#item11100701" xml:id="item11100701">
 <anchor xml:id="app1110070101"/><anchor xml:id="app1110070101e"/>
                         凡左右弁官一人、向<anchor xml:id="app1110070102"/>上庁<anchor xml:id="app1110070102e"/>受事、若左事右受、右事左受者、並令相知、但受事弁施行、<lb/></p>
+                        <app from="#app1110070101" to="#app1110070101e">
+                                                <lem wit="#土本">弘</lem>
+                        </app>
+                        <app from="#app1110070102" to="#app1110070102e">
+                                                <lem wit="#土本">上庁</lem>
+                                                <note place="傍">土本・近本・壬本・京博本・慶長本傍書「上庁正庁也」</note>
+                                                <note>上庁　土本・近本・壬本・京博本・慶長本傍書「上庁正庁也」。</note>
+                        </app>
 </div>
 <div ana="太政官" n="11.8" subtype="項" type="条">
 <head ana="弁官牒式"/>
@@ -94,8 +137,19 @@
 <lb/></p>
 <p ana="項" corresp="engishiki_ja.xml#item11100805 engishiki_en.xml#item11100805" xml:id="item11100805">下民部・宮内等省為給諸司其月公粮事一通<lb/>下民部省為応徴免其季課役事一通<lb/>　　右<anchor xml:id="app1110080501"/>二<anchor xml:id="app1110080501e"/>通請外印、<lb/>
 <lb/></p>
+                        <app from="#app1110080501" to="#app1110080501e">
+                                                <lem>二</lem>
+                                                <rdg wit="#諸本">三</rdg>
+                                                <note>二　諸本「三」。文意により改める。</note>
+                        </app>
 <p ana="項" corresp="engishiki_ja.xml#item11100806 engishiki_en.xml#item11100806" xml:id="item11100806">牒、件入奏文書并請進駅鈴・伝符及請印文書、具件如前、故牒、<lb/> 　　　　　　年月日　　左史位姓名牒<lb/>
 <anchor xml:id="app1110080601"/>左<anchor xml:id="app1110080601e"/>弁位姓名<lb/></p>
+                        <app from="#app1110080601" to="#app1110080601e">
+                                                <lem wit="#九本">左</lem>
+                                                <rdg wit="#土本 #等">右</rdg>
+                                                <note place="頭">京博本朱頭書「<seg style="color:red">右疑左誤</seg>」</note>
+                                                <note>左　土本等「右」。京博本朱頭書「右疑左誤」。九本により改める。</note>
+                        </app>
 </div>
 <div ana="太政官" n="11.9" subtype="項" type="条">
 <head ana="少納言牒式"/>
@@ -103,19 +157,70 @@
 <anchor xml:id="app1110090101"/><anchor xml:id="app1110090101e"/>
                         少納言牒弁官式<lb/>其国司申送調庸及中男作物等帳若干通<lb/>式部省申為応給諸司春夏禄事一通<lb/>兵部省申為同前事一通<lb/>　　右若干通、其日少納言其奏訖、<lb/>
 <lb/></p>
+                        <app from="#app1110090101" to="#app1110090101e">
+                                                <lem wit="#土本">弘</lem>
+                        </app>
 <p ana="項" corresp="engishiki_ja.xml#item11100902 engishiki_en.xml#item11100902" xml:id="item11100902">其国正税帳使官位姓名所進若干刻駅鈴一口<lb/>其国守位姓名赴任日所給若干刻伝符一枚<lb/>　　右駅鈴一口・伝符一枚、其日少納言其<anchor xml:id="app1110090201"/>進<anchor xml:id="app1110090201e"/>訖、<lb/>
 <lb/></p>
+                        <app from="#app1110090201" to="#app1110090201e">
+                                                <lem wit="#土本">進</lem>
+                                                <rdg wit="#訳注本">請進</rdg>
+                                                <note>進　訳注本「請進」。</note>
+                        </app>
 <p ana="項" corresp="engishiki_ja.xml#item11100903 engishiki_en.xml#item11100903" xml:id="item11100903">下其国為正税帳使官位姓名事畢還任事一通、若干刻駅鈴一口<lb/>下其国為位姓名任守事一通、若干刻伝符一枚<lb/>民部省下其国為給官位姓名食封事一通<lb/>　　右内印三<anchor xml:id="app1110090301"/>通<anchor xml:id="app1110090301e"/>、其日少納言其請印并駅鈴一口・伝符一枚訖、<lb/>
 <lb/></p>
+                        <app from="#app1110090301" to="#app1110090301e"> 
+                                                <lem wit="#土本">通</lem>
+                                                <rdg wit="#九本">道</rdg>
+                                                <note>通　九本「道」。</note>
+                        </app>
 <p ana="項" corresp="engishiki_ja.xml#item11100904 engishiki_en.xml#item11100904" xml:id="item11100904">下民部・宮内等省為給諸司其月公粮事一通<lb/>下民部省為応徴免其季課役事一通<lb/> 　　右外印二通、其日少納言其監印訖、<lb/>
 <lb/></p>
 <p ana="項" corresp="engishiki_ja.xml#item11100905 engishiki_en.xml#item11100905" xml:id="item11100905">牒、具件如前、至請検領、故牒、<lb/>　　　　　　　年月日　外記位姓名牒<lb/>少納言位姓<anchor xml:id="app1110090501"/>名<anchor xml:id="app1110090501e"/><lb/></p>
+                        <app from="#app1110090501" to="#app1110090501e">
+                                                <lem wit="#九本">名</lem>
+                                                <rdg wit="#土本 #等">名〈古式、少納言署於下、今改署於上〉</rdg>
+                                                <note>名　土本等この下に細字注「古式、少納言署於下、今改署於上」あり。九本に無く、後の書入と判断する。</note>
+                        </app>
 </div>
 <div ana="太政官" n="11.10" subtype="項" type="条">
 <head ana="任僧綱"/>
 <p ana="項" corresp="engishiki_ja.xml#item11101001 engishiki_en.xml#item11101001" xml:id="item11101001">
 <anchor xml:id="app1110100101"/><anchor xml:id="app1110100101e"/>
-                        凡任僧綱者、弁官預仰式部・治部等省、其日遣<anchor xml:id="app1110100102"/>勅使<anchor xml:id="app1110100102e"/>参議、〈賜宣命文、〉及少納言・弁・式部輔・治部輔・玄蕃頭等各一人共向僧綱所、〈僧綱所預設座、〉勅使以宣命文授少納言、少納言受而就座、宣制、訖勅使以下還<anchor xml:id="app1110100103"/>帰<anchor xml:id="app1110100103e"/>、〈若不<anchor xml:id="app1110100104"/>遣<anchor xml:id="app1110100104e"/>勅使、直下符治部省、〉<anchor xml:id="app1110100105"/>然後太政官牒送僧綱、其告牒式如<anchor xml:id="app1110100105e"/>左<anchor xml:id="app1110100106"/>、〈事見儀式、〉<anchor xml:id="app1110100106e"/><lb/></p>
+                        凡任僧綱者、弁官預仰式部・治部等省、其日遣<anchor xml:id="app1110100102"/>勅使<anchor xml:id="app1110100102e"/>参議、〈賜宣命文、〉及少納言・弁・式部輔・治部輔・玄蕃頭等各一人共向僧綱所、〈僧綱所預設座、〉勅使以宣命文授少納言、少納言受而就座、宣制、訖勅使以下還<anchor xml:id="app1110100103"/>帰<anchor xml:id="app1110100103e"/>、〈若不<anchor xml:id="app1110100104"/>遣<anchor xml:id="app1110100104e"/>勅使、直下符治部省、〉<anchor xml:id="app1110100105"/>然後太政官牒送僧綱、其告牒式如<anchor xml:id="app1110100106"/>左<anchor xml:id="app1110100106e"/>、〈事見儀式、〉<anchor xml:id="app1110100105e"/><lb/></p>
+                        <app from="#app1110100101" to="#app1110100101e">
+                                                <lem wit="#諸本"/>
+                                                <rdg wit="#訳注本">弘</rdg>
+                                                <note>訳注本、鼇頭標目「弘」を記すも諸本無し。</note>
+                        </app>
+                        <app from="#app1110100102" to="#app1110100102e">
+                                                <lem wit="#近本訂正書 #京博本朱訂">勅使</lem>
+                                                <rdg wit="#土本 #等">使勅</rdg>
+                                                <rdg wit="#九本">使</rdg>
+                                                <note>土本等「使勅」。九本は「勅」まで欠損し、「使参議」と記す。近本訂正書・京博本朱訂により改める。</note>
+                        </app>
+                        <app from="#app1110100103" to="#app1110100103e">
+                                                <lem wit="#九本">帰</lem>
+                                                <rdg wit="#土本 #等">帰〈局本自若干至治部省住〉</rdg>
+                                                <rdg wit="#近本 #京博本 #壬本 #等">帰〈局本自若干至治部省注〉</rdg>
+                                                <note>帰　土本等この下に細字注「局本自若干至治部省住（近本・京博本・壬本等「注」）」あり。九本に無く、後の書入と判断する。</note>
+                        </app>
+                        <app from="#app1110100104" to="#app1110100104e">
+                                                <lem wit="#九本 #近本等訂正書">遣</lem>
+                                                <rdg wit="#土本 #等">違</rdg>
+                                                <note>遣　土本等「違」。九本・近本等訂正書により改める。</note>
+                        </app>
+                        <app from="#app1110100105" to="#app1110100105e">
+                                                <lem wit="#九本 #京博本朱傍書">然後太政官牒送僧綱、其告牒式如</lem>
+                                                <rdg wit="#土本 #等">〈然後太政官牒送僧綱、其告牒式如〉</rdg>
+                                                <note place="傍">京博本朱傍書「<seg style="color:red">以下十五字本行</seg>」</note>
+                                                <note>然後太政官牒送僧綱、其告牒式如　土本等細字注とする。九本、京博本朱傍書（「以下十五字本行」）により改める。</note>
+                        </app>
+                        <app from="#app1110100106" to="#app1110100106e">
+                                                <lem wit="#九本書入 #近本書入">左</lem>
+                                                <rdg wit="#土本"></rdg>
+                                                <note>左　土本無し。九本・近本書入等により補う。</note>
+                        </app>
 <p ana="項" corresp="engishiki_ja.xml#item11101002 engishiki_en.xml#item11101002" xml:id="item11101002">太政官牒　僧綱<lb/>
 <anchor xml:id="app1110100201"/>其<anchor xml:id="app1110100201e"/>位<anchor xml:id="app1110100202"/>其<anchor xml:id="app1110100202e"/>令擬僧正位<lb/> 　　右一人擬官如右、<lb/>
                         勅、依前件告僧正<anchor xml:id="app1110100203"/>其<anchor xml:id="app1110100203e"/>、今以状牒、々到准状、故牒、<lb/> 　　　　　年　月　日外記位姓名牒<lb/> 大納言位姓<lb/>


### PR DESCRIPTION
・8条校訂注2　京博本朱頭書は傍書の形を参照に記述してみました。
・10条校訂注5・6　校訂注IDの位置を訂正。注5は「然後太政官牒送僧綱、其告牒式如左」の説明をし、文末の「左」について注6でさらに説明を加えているため。