### PR TITLE
XML修正: app要素のID参照とfacsimileセクションの更新

### DIFF
--- a/TEI編集用/engishiki_v42-1.xml
+++ b/TEI編集用/engishiki_v42-1.xml
@@ -2056,7 +2056,7 @@
        <note style="傍"> 享保版本朱傍書「 <seg style="color:red"> 〈イ〉基〈一本〉 </seg> 」 </note>
        <note> 垣　鈴鹿本・筑波寛文本この下に朱挿入符を付し、鈴鹿本朱傍書「基」、筑波寛文本朱傍書「基〈一本〉」。享保版本朱傍書「〈イ〉基〈一本〉」。 </note>
       </app>
-      <app from="#app4210581002" to="#app421058100e">
+      <app from="#app4210581002" to="#app4210581002e">
        <lem wit="#九本 #京博本朱補書 #慶安版本 #鈴鹿本 #明暦版本 #寛文版本 #筑波寛文本 #享保版本 #雲本"> 丈 </lem>
        <rdg wit="#土本 #近本 #壬本 #京博本 #慶長本 #梵本"/>
        <note> 京博本朱補書「 <seg style="color:red"> 丈イ </seg> 」 </note>
@@ -2212,5 +2212,23 @@
     url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00013.tif/full/full/0/default.jpg"
    />
   </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5163"
+             xml:id="page5163">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00014.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5164"
+             xml:id="page5164">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00015.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5165"
+             xml:id="page5165">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00016.tif/full/full/0/default.jpg"
+        />
+    </surface>
  </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v42-2.xml
+++ b/TEI編集用/engishiki_v42-2.xml
@@ -914,23 +914,101 @@
   </body>
  </text>
  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-42/manifest.json">
-  <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5163"
-   xml:id="page5163">
-   <graphic
-    url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00014.tif/full/full/0/default.jpg"
-   />
-  </surface>
-  <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5164"
-   xml:id="page5164">
-   <graphic
-    url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00015.tif/full/full/0/default.jpg"
-   />
-  </surface>
-  <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5165"
-   xml:id="page5165">
-   <graphic
-    url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00016.tif/full/full/0/default.jpg"
-   />
-  </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5150"
+             xml:id="page5150">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00001.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5151"
+             xml:id="page5151">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00002.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5152"
+             xml:id="page5152">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00003.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5153"
+             xml:id="page5153">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00004.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5154"
+             xml:id="page5154">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00005.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5155"
+             xml:id="page5155">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00006.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5156"
+             xml:id="page5156">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00007.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5157"
+             xml:id="page5157">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00008.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5158"
+             xml:id="page5158">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00009.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5159"
+             xml:id="page5159">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00010.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5160"
+             xml:id="page5160">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00011.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5161"
+             xml:id="page5161">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00012.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5162"
+             xml:id="page5162">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00013.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5163"
+             xml:id="page5163">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00014.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5164"
+             xml:id="page5164">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00015.tif/full/full/0/default.jpg"
+        />
+    </surface>
+    <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5165"
+             xml:id="page5165">
+      <graphic
+        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00016.tif/full/full/0/default.jpg"
+        />
+    </surface>
  </facsimile>
 </TEI>


### PR DESCRIPTION
## 概要
延喜式TEIファイルのXML修正を行いました。

## 変更内容
- **engishiki_v42-1.xml**: 
  - app要素のto属性のID参照を修正（`#app421058100e` → `#app4210581002e`）
  - facsimileセクションにpage5163-5165を追加
- **engishiki_v42-2.xml**: 
  - facsimileセクションを完全版に更新（page5150-5165を含む）

## テストプラン
- [ ] XMLファイルの妥当性検証
- [ ] ID参照の整合性確認
- [ ] facsimileセクションの画像URL確認

🤖 Generated with [Claude Code](https://claude.ai/code)