### PR TITLE
Fix anchor element position in TEI XML

### DIFF
--- a/TEI編集用/engishiki_v11.xml
+++ b/TEI編集用/engishiki_v11.xml
@@ -3169,8 +3169,8 @@
        <anchor xml:id="app1111290101"/>
        <anchor xml:id="app1111290101e"/> 凡 <orgName corresp="#式部省"> 式 </orgName>
        <anchor xml:id="app1111290102"/>
-       <orgName corresp="#兵部省"> 兵 <anchor xml:id="app1111290102e"/>
-       </orgName> 二省請印准蔭・成選等位記、先令印廿張已下、後更定日、参議於弁官結政所捺了、〈所須丹・膠等物、預先請受、〉 </p>
+       <orgName corresp="#兵部省"> 兵 
+       </orgName> <anchor xml:id="app1111290102e"/>二省請印准蔭・成選等位記、先令印廿張已下、後更定日、参議於弁官結政所捺了、〈所須丹・膠等物、預先請受、〉 </p>
       <app from="#app1111290101" to="#app1111290101e" type="標注">
        <lem> 貞延 </lem>
       </app>


### PR DESCRIPTION
## Summary
- orgName要素内のanchor要素の位置を修正
- XML構造を適切な形に調整

## 変更内容
`TEI編集用/engishiki_v11.xml`のline 3172-3173において、`</orgName>`タグの前にあったanchor要素を外側に移動しました。

🤖 Generated with [Claude Code](https://claude.ai/code)