### PR TITLE
IIIF画像・manifest URLを khirin-a から iiif.rekihaku へ移行

### DIFF
--- a/TEI編集用/engishiki_v10.xml
+++ b/TEI編集用/engishiki_v10.xml
@@ -1373,7 +1373,7 @@
   <text>
     <body>
       <div ana="神名下" n="10" type="巻" xml:id="volume10">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai10">
           <p xml:id="shudai1001"><anchor xml:id="app1066660101"/> 延喜式巻第十 <anchor xml:id="app1066660101e"/> 〈 <orgName
               corresp="#神祇官"> 神祇 </orgName> 十〉 </p>
@@ -1427,7 +1427,7 @@
                   <cell rendition="#width300"> 神田神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00003.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00003.tif/full/full/0/default.jpg"
                     /> 小野神社二座〈名神大、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 日吉神社〈名神大、〉 </cell>
@@ -1547,7 +1547,7 @@
                   <cell rendition="#width300"> 奥石神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00004.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00004.tif/full/full/0/default.jpg"
                     /> 石部神社 </cell>
                 </row>
                 <row>
@@ -1677,7 +1677,7 @@
                   <cell rendition="#width300"> 湯次神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00005.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00005.tif/full/full/0/default.jpg"
                     /> 波久奴神社 </cell>
                 </row>
                 <row>
@@ -1773,7 +1773,7 @@
                   <cell rendition="#width300"> 佐味神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00006.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00006.tif/full/full/0/default.jpg"
                     /> 椿神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 佐波 <anchor xml:id="app1010021205"/> 加 <anchor xml:id="app1010021205e"/> 刀神社
@@ -1903,7 +1903,7 @@
                   <cell rendition="#width300"> 櫟原神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00007.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00007.tif/full/full/0/default.jpg"
                     /> 大田神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 鞆結神社 </cell>
@@ -2034,7 +2034,7 @@
               <rdg wit="#土本"> 三 </rdg>
               <note> 二　土本「三」、永本・九本・吉本・京博本「二」。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00008.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00008.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10100304 engishiki_v10_ja.xml#item10100304" xml:id="item10100304">
               <table rendition="#indent">
                 <row>
@@ -2141,7 +2141,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10100310 engishiki_v10_ja.xml#item10100310" xml:id="item10100310">
               <seg rendition="#indent"> 賀茂郡九座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00009.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00009.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 県主神社 </cell>
@@ -2239,7 +2239,7 @@
                 ><placeName corresp="#信濃国"> 信濃国 </placeName> 卌八座〈大七座、小卌一座、〉 </p>
             <p ana="項" corresp="engishiki_v10_en.xml#item10100502 engishiki_v10_ja.xml#item10100502" xml:id="item10100502">
               <seg rendition="#indent"> 伊那郡二座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00010.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00010.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 大山田神社 </cell>
@@ -2379,7 +2379,7 @@
                   <cell rendition="#width300"> 小川神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00011.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00011.tif/full/full/0/default.jpg"
                     /> 守田神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 粟野神社 </cell>
@@ -2506,7 +2506,7 @@
               </table>
             </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00012.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00012.tif/full/full/0/default.jpg"/>
           <div ana="神名下" corresp="engishiki_v10_en.xml#article101006 engishiki_v10_ja.xml#article101006" n="10.6" type="条"
             xml:id="article101006">
             <head ana="上野国"/>
@@ -2630,7 +2630,7 @@
             <p ana="項" corresp="engishiki_v10_en.xml#item10100702 engishiki_v10_ja.xml#item10100702" xml:id="item10100702">
               <seg rendition="#indent"><anchor xml:id="app1010070201"/><anchor xml:id="app1010070201e"/> 都賀 <anchor
                   xml:id="app1010070202"/> 郡 <anchor xml:id="app1010070202e"/> 三座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00013.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00013.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 大 <anchor xml:id="app1010070203"/> 神 <anchor xml:id="app1010070203e"/> 社 </cell>
@@ -2788,7 +2788,7 @@
                 <seg rendition="#shu"> 貞 </seg>
               </lem>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00014.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00014.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10100803 engishiki_v10_ja.xml#item10100803" xml:id="item10100803">
               <table rendition="#indent">
                 <row>
@@ -2939,7 +2939,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10100810 engishiki_v10_ja.xml#item10100810" xml:id="item10100810">
               <seg rendition="#indent"> 曰理郡四座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00015.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00015.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 鹿島伊都乃比気神社 </cell>
@@ -3092,7 +3092,7 @@
                   <cell rendition="#width300"> 香取伊豆乃御子神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00016.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00016.tif/full/full/0/default.jpg"
                     /> 伊去波夜和気命神社 </cell>
                 </row>
                 <row>
@@ -3239,7 +3239,7 @@
                   <cell rendition="#width300"><anchor xml:id="app1010081802"/> 駒形根 <anchor xml:id="app1010081802e"/> 神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00017.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00017.tif/full/full/0/default.jpg"
                     /> 和我神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 香取御児神社 </cell>
@@ -3400,7 +3400,7 @@
                   <cell rendition="#width300"><anchor xml:id="app1010082501"/> 斯波郡 <anchor xml:id="app1010082501e"/> 一座〈小、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00018.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00018.tif/full/full/0/default.jpg"
                       /><anchor xml:id="app1010082502"/><anchor xml:id="app1010082502e"/> 志賀理和気神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"/>
@@ -3578,7 +3578,7 @@
               <note place="脚"> 永本脚書「気佐肩神社　郡可尋之、」 </note>
               <note place="脚"> 吉本脚書「気佐肩神社　郡可尋之、」 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00019.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00019.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10100902 engishiki_v10_ja.xml#item10100902" xml:id="item10100902">
               <seg rendition="#indent"> 飽海郡三座〈大二座、小一座、〉 </seg>
               <table>
@@ -3686,7 +3686,7 @@
                 </row>
                 <row>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00020.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00020.tif/full/full/0/default.jpg"
                     /> 波古神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 久須夜神社 </cell>
@@ -3797,7 +3797,7 @@
                   <cell rendition="#width300"> 弥美神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00021.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00021.tif/full/full/0/default.jpg"
                       /><anchor xml:id="app1010110403"/> 於 <anchor xml:id="app1010110403e"/> 世神社 </cell>
                 </row>
                 <row>
@@ -3911,7 +3911,7 @@
                   <cell rendition="#width300"> 三前神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00022.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00022.tif/full/full/0/default.jpg"
                     /> 織田神社 </cell>
                 </row>
                 <row>
@@ -4041,7 +4041,7 @@
                   <cell rendition="#width300"> 刀那神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00023.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00023.tif/full/full/0/default.jpg"
                     /> 小山田神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 鵜甘神社 </cell>
@@ -4206,7 +4206,7 @@
                   <cell rendition="#width300"> 坂名井神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00024.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00024.tif/full/full/0/default.jpg"
                     /> 御前神社 </cell>
                 </row>
                 <row>
@@ -4328,7 +4328,7 @@
                   <cell rendition="#width300"> 篠原神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00025.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00025.tif/full/full/0/default.jpg"
                     /> 刀何理神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 御木神社 </cell>
@@ -4467,7 +4467,7 @@
                   <cell rendition="#width300"> 野間神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00026.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00026.tif/full/full/0/default.jpg"
                     /> 三輪神社 </cell>
                 </row>
                 <row>
@@ -4624,7 +4624,7 @@
                   <cell rendition="#width300"> 加夫刀比古神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00027.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00027.tif/full/full/0/default.jpg"
                     /> 天日陰比 <anchor xml:id="app1010140302"/> 咩 <anchor xml:id="app1010140302e"/> 神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 鳥屋 <anchor xml:id="app1010140303"/> 比古 <anchor xml:id="app1010140303e"/> 神社
@@ -4806,7 +4806,7 @@
               <table>
                 <row>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00028.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00028.tif/full/full/0/default.jpg"
                     /> 高瀬神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 長岡神社 </cell>
@@ -4976,7 +4976,7 @@
                   <cell rendition="#width300"> 建石勝神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00029.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00029.tif/full/full/0/default.jpg"
                     /> 櫟原神社 </cell>
                 </row>
                 <row>
@@ -5097,7 +5097,7 @@
                   <cell rendition="#width300"> 物部神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00030.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00030.tif/full/full/0/default.jpg"
                     /> 鵜 <anchor xml:id="app1010160402"/> 川 <anchor xml:id="app1010160402e"/> 神社 </cell>
                 </row>
                 <row>
@@ -5239,7 +5239,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10101608 engishiki_v10_ja.xml#item10101608" xml:id="item10101608">
               <seg rendition="#indent"><anchor xml:id="app1010160801"/> 磐 <anchor xml:id="app1010160801e"/> 船郡八座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00031.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00031.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 石船神社 </cell>
@@ -5374,7 +5374,7 @@
                 ><placeName corresp="#丹波国"> 丹波国 </placeName> 七十一座〈大五座、小六十六座、〉 </p>
             <p ana="項" corresp="engishiki_v10_en.xml#item10101902 engishiki_v10_ja.xml#item10101902" xml:id="item10101902">
               <seg rendition="#indent"><anchor xml:id="app1010190201"/><anchor xml:id="app1010190201e"/> 桑田郡十九座〈大二座、小十七座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00032.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00032.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app1010190202"/> 出雲神社 <anchor xml:id="app1010190202e"/> 〈名神大、〉 </cell>
@@ -5531,7 +5531,7 @@
                       <anchor xml:id="app1010190402"/> 大 <anchor xml:id="app1010190402e"/> 、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00033.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00033.tif/full/full/0/default.jpg"
                     /> 神田神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 川内多多奴比神社二座 </cell>
@@ -5673,7 +5673,7 @@
                   <cell rendition="#width300"> 阿比地神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00034.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00034.tif/full/full/0/default.jpg"
                     /> 阿須 <anchor xml:id="app1010190701"/> 須 <anchor xml:id="app1010190701e"/> 伎神 <anchor
                       xml:id="app1010190702"/> 社 <anchor xml:id="app1010190702e"/>
                   </cell>
@@ -5815,7 +5815,7 @@
                   <cell rendition="#width300"> 久理陀神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00035.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00035.tif/full/full/0/default.jpg"
                     /> 多由神社 </cell>
                 </row>
                 <row>
@@ -5949,7 +5949,7 @@
                   <cell rendition="#width300"> 志布比神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00036.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00036.tif/full/full/0/default.jpg"
                     /> 深田部神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 床尾神社 </cell>
@@ -6118,7 +6118,7 @@
                       <anchor xml:id="app1010210302"/> 大二座 <anchor xml:id="app1010210302e"/> 、小三座、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00037.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00037.tif/full/full/0/default.jpg"
                     /> 宇留波神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><anchor xml:id="app1010210303"/> 水谷神社 <anchor xml:id="app1010210303e"/> 〈名神大、〉
@@ -6253,7 +6253,7 @@
                   <cell rendition="#width300"> 日出神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00038.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00038.tif/full/full/0/default.jpg"
                     /> 須義神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 小野神社 </cell>
@@ -6396,7 +6396,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10102106 engishiki_v10_ja.xml#item10102106" xml:id="item10102106">
               <seg rendition="#indent"> 城埼郡廿一座〈大一座、小廿座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00039.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00039.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 物部神社 </cell>
@@ -6507,7 +6507,7 @@
                   <cell rendition="#width300"> 大家神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00040.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00040.tif/full/full/0/default.jpg"
                     /> 大歳神社 </cell>
                 </row>
                 <row>
@@ -6658,7 +6658,7 @@
                 吉本脚書「本縁分／武内宿禰垂跡也、仁徳天皇治世五十五年春三月ノ比、御歳三百六十余歳、当御下向於亀山金ノ隻履残シ御陰所ヲ不知、六代ノ御門御後見也、当国宇倍山・大和葛城堺・美濃国不破ノ関、是三箇国ニ同日同時ニ顕御座ス云々、」
               </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00041.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00041.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10102204 engishiki_v10_ja.xml#item10102204" xml:id="item10102204">
               <seg rendition="#indent"> 八上郡十九座〈並小、〉 </seg>
               <table>
@@ -6780,7 +6780,7 @@
                   <cell rendition="#width300"><anchor xml:id="app1010220702"/> 板 <anchor xml:id="app1010220702e"/> 井神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00042.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00042.tif/full/full/0/default.jpg"
                     /> 志加奴神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"/>
@@ -6909,7 +6909,7 @@
                   <cell rendition="#width300"> 久多 <anchor xml:id="app1010240207"/> 弥 <anchor xml:id="app1010240207e"/> 神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00043.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00043.tif/full/full/0/default.jpg"
                     /> 玉作湯神社 </cell>
                 </row>
                 <row>
@@ -7115,7 +7115,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10102403 engishiki_v10_ja.xml#item10102403" xml:id="item10102403">
               <seg rendition="#indent"> 島根郡十四座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00044.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00044.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 布自伎美神社 </cell>
@@ -7226,7 +7226,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 能呂志神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00045.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00045.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 許豆神社 </cell>
                   <cell rendition="#width50"/>
@@ -7295,7 +7295,7 @@
                   <cell rendition="#width300"> 同社神阿麻能比奈等理神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00046.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00046.tif/full/full/0/default.jpg"
                     /> 同社神伊佐我神社 </cell>
                 </row>
                 <row>
@@ -7373,7 +7373,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 神代神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00047.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00047.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 曾 <anchor xml:id="app1010240618"/> 枳 <anchor xml:id="app1010240618e"/> 能夜神社 </cell>
                   <cell rendition="#width50"/>
@@ -7577,7 +7577,7 @@
                   <cell rendition="#width300"> 塩 <anchor xml:id="app1010240706"/> 冶 <anchor xml:id="app1010240706e"/> 神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00048.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00048.tif/full/full/0/default.jpg"
                     /> 富能加神社 </cell>
                 </row>
                 <row>
@@ -7749,7 +7749,7 @@
                   <cell rendition="#width300"> 加多神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00049.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00049.tif/full/full/0/default.jpg"
                     /> 佐世神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><anchor xml:id="app1010241003"/> 西利太神社 <anchor xml:id="app1010241003e"/>
@@ -7927,7 +7927,7 @@
                   <cell rendition="#width300"> 大麻山神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00050.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00050.tif/full/full/0/default.jpg"
                     /> 石見天豊足柄姫命神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 大祭天石門彦神社 </cell>
@@ -8110,7 +8110,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10102603 engishiki_v10_ja.xml#item10102603" xml:id="item10102603">
               <seg rendition="#indent"> 海部郡二座〈大一座、小一座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00051.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00051.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 奈伎良比売命神社 </cell>
@@ -8281,7 +8281,7 @@
                 </row>
               </table>
             </p>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00052.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00052.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10102804 engishiki_v10_ja.xml#item10102804" xml:id="item10102804">
               <seg rendition="#indent"><anchor xml:id="app1010280401"/><anchor xml:id="app1010280401e"/> 飾磨郡四座〈並小、〉 </seg>
               <table>
@@ -8443,7 +8443,7 @@
               <note place="傍"> 京博本朱傍書「 <seg rendition="#shu"> 玉イ </seg> 」 </note>
               <note> 王　永本「玉」。土本・九本・花本・吉本・京博本・西本「王」。京博本朱傍書「玉イ」。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00053.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00053.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10102809 engishiki_v10_ja.xml#item10102809" xml:id="item10102809">
               <table rendition="#indent">
                 <row>
@@ -8574,7 +8574,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 菟上神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00054.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00054.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 長田神社 </cell>
                   <cell rendition="#width50"/>
@@ -8768,7 +8768,7 @@
                   <cell rendition="#width300"> 伊勢神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00055.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00055.tif/full/full/0/default.jpg"
                       /><anchor xml:id="app1010300605"/> 尾針神社 <anchor xml:id="app1010300605e"/>
                   </cell>
                   <cell rendition="#width50"/>
@@ -8919,7 +8919,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10103105 engishiki_v10_ja.xml#item10103105" xml:id="item10103105">
               <seg rendition="#indent"> 小田郡三座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00056.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00056.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 在田神社 </cell>
@@ -9081,7 +9081,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10103207 engishiki_v10_ja.xml#item10103207" xml:id="item10103207">
               <seg rendition="#indent"> 葦田郡二座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00057.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00057.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 賀 <anchor xml:id="app1010320701"/> 茂 <anchor xml:id="app1010320701e"/> 奈
@@ -9325,7 +9325,7 @@
                 <seg rendition="#shu"> 貞 </seg>
               </lem>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00058.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00058.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10103404 engishiki_v10_ja.xml#item10103404" xml:id="item10103404">
               <table rendition="#indent">
                 <row>
@@ -9480,7 +9480,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 鳴神社〈名神大、月次、相嘗、新嘗、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00059.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00059.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app1010370404"/> 香都知神社 <anchor xml:id="app1010370404e"/>
                   </cell>
@@ -9708,7 +9708,7 @@
               <note place="脚"> 永本脚書「由津理羽社」 </note>
               <note place="脚"> 吉本脚書「由津理羽神」 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00060.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00060.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10103803 engishiki_v10_ja.xml#item10103803" xml:id="item10103803">
               <seg rendition="#indent"><anchor xml:id="app1010380301"/><anchor xml:id="app1010380301e"/><anchor
                   xml:id="app1010380302"/> 三 <anchor xml:id="app1010380302e"/> 原郡四座〈大一座、小三座、〉 </seg>
@@ -9863,7 +9863,7 @@
                   <cell rendition="#width300"> 忌部神社〈名神大、月次、新嘗、或号麻殖神、或号天日鷲神、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00061.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00061.tif/full/full/0/default.jpg"
                     /> 天村雲神伊自波夜比売神社二座 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"/>
@@ -10015,7 +10015,7 @@
                   <cell rendition="#width300"> 宇奈為神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00062.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00062.tif/full/full/0/default.jpg"
                     /> 和 <anchor xml:id="app1010390801"/> 奈 <anchor xml:id="app1010390801e"/> 佐意富曾神社 </cell>
                 </row>
                 <row>
@@ -10152,7 +10152,7 @@
             </p>
             <p ana="項" corresp="engishiki_v10_en.xml#item10104008 engishiki_v10_ja.xml#item10104008" xml:id="item10104008">
               <seg rendition="#indent"> 多度郡二座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00063.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00063.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 大麻神社 </cell>
@@ -10329,7 +10329,7 @@
                   <cell rendition="#width300"><anchor xml:id="app1010410507"/><anchor xml:id="app1010410507e"/><anchor
                       xml:id="app1010410508"/> 多伎神社 <anchor xml:id="app1010410508e"/> 〈名神大、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00064.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00064.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 樟本神社 </cell>
                   <cell rendition="#width50"/>
@@ -10534,7 +10534,7 @@
             </p>
             <p ana="項" corresp="engishiki_v10_en.xml#item10104204 engishiki_v10_ja.xml#item10104204" xml:id="item10104204">
               <seg rendition="#indent"><anchor xml:id="app1010420401"/><anchor xml:id="app1010420401e"/> 長岡郡五座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00065.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00065.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 豊岡上天神社 </cell>
@@ -10698,7 +10698,7 @@
               <lem wit="#土本 #永本 #九本 #花本 #吉本 #京博本"> 住吉神社 </lem>
               <note place="頭"> 永本朱頭注「 <seg rendition="#shu"> 表筒男、中筒男、底筒男、 </seg> 」 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00066.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00066.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v10_en.xml#item10104404 engishiki_v10_ja.xml#item10104404" xml:id="item10104404">
               <table rendition="#indent">
                 <row>
@@ -10890,7 +10890,7 @@
             </app>
             <p ana="項" corresp="engishiki_v10_en.xml#item10104603 engishiki_v10_ja.xml#item10104603" xml:id="item10104603">
               <seg rendition="#indent"><anchor xml:id="app1010460301"/><anchor xml:id="app1010460301e"/> 田川郡三座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00067.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00067.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app1010460302"/><anchor xml:id="app1010460302e"/> 辛国息長大姫大
@@ -11177,7 +11177,7 @@
               </lem>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00068.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00068.tif/full/full/0/default.jpg"/>
           <div ana="神名下" corresp="engishiki_v10_en.xml#article101050 engishiki_v10_ja.xml#article101050" n="10.50" type="条"
             xml:id="article101050">
             <head ana="日向国"/>
@@ -11424,7 +11424,7 @@
                   <cell rendition="#width300"> 兵主神社〈名神大、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00069.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00069.tif/full/full/0/default.jpg"
                     /> 月読神社〈名神大、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 国片主神社 </cell>
@@ -11597,7 +11597,7 @@
                 </row>
                 <row>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00070.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00070.tif/full/full/0/default.jpg"
                     /> 行相神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><anchor xml:id="app1010540203"/><anchor xml:id="app1010540203e"/>
@@ -11801,7 +11801,7 @@
               <row>
                 <cell/>
                 <cell><pb
-                    facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00071.tif/full/full/0/default.jpg"
+                    facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00071.tif/full/full/0/default.jpg"
                     /><anchor xml:id="app1099990106"/> 大納言正三位兼行 <orgName corresp="#民部省"> 民部 </orgName> 卿臣藤原朝臣清貫 <anchor
                     xml:id="app1099990106e"/>
                 </cell>
@@ -11882,222 +11882,222 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-10/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-10">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4114" xml:id="page4114">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4115" xml:id="page4115">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4116" xml:id="page4116">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4117" xml:id="page4117">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4118" xml:id="page4118">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4119" xml:id="page4119">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4120" xml:id="page4120">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4121" xml:id="page4121">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4122" xml:id="page4122">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4123" xml:id="page4123">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4124" xml:id="page4124">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4125" xml:id="page4125">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4126" xml:id="page4126">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4127" xml:id="page4127">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4128" xml:id="page4128">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4129" xml:id="page4129">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4130" xml:id="page4130">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4131" xml:id="page4131">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4132" xml:id="page4132">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4133" xml:id="page4133">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4134" xml:id="page4134">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4135" xml:id="page4135">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4136" xml:id="page4136">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4137" xml:id="page4137">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4138" xml:id="page4138">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4139" xml:id="page4139">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4140" xml:id="page4140">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4141" xml:id="page4141">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4142" xml:id="page4142">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4143" xml:id="page4143">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4144" xml:id="page4144">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4145" xml:id="page4145">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4146" xml:id="page4146">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4147" xml:id="page4147">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4148" xml:id="page4148">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4149" xml:id="page4149">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00036.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4150" xml:id="page4150">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00037.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00037.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4151" xml:id="page4151">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00038.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00038.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4152" xml:id="page4152">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00039.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00039.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4153" xml:id="page4153">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00040.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00040.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4154" xml:id="page4154">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00041.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00041.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4155" xml:id="page4155">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00042.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00042.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4156" xml:id="page4156">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00043.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00043.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4157" xml:id="page4157">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00044.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00044.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4158" xml:id="page4158">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00045.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00045.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4159" xml:id="page4159">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00046.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00046.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4160" xml:id="page4160">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00047.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00047.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4161" xml:id="page4161">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00048.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00048.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4162" xml:id="page4162">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00049.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00049.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4163" xml:id="page4163">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00050.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00050.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4164" xml:id="page4164">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00051.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00051.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4165" xml:id="page4165">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00052.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00052.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4166" xml:id="page4166">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00053.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00053.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4167" xml:id="page4167">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00054.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00054.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4168" xml:id="page4168">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00055.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00055.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4169" xml:id="page4169">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00056.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00056.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4170" xml:id="page4170">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00057.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00057.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4171" xml:id="page4171">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00058.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00058.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4172" xml:id="page4172">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00059.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00059.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4173" xml:id="page4173">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00060.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00060.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4174" xml:id="page4174">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00061.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00061.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4175" xml:id="page4175">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00062.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00062.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4176" xml:id="page4176">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00063.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00063.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4177" xml:id="page4177">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00064.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00064.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4178" xml:id="page4178">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00065.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00065.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4179" xml:id="page4179">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00066.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00066.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4180" xml:id="page4180">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00067.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00067.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4181" xml:id="page4181">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00068.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00068.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4182" xml:id="page4182">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00069.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00069.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4183" xml:id="page4183">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00070.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00070.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4184" xml:id="page4184">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00071.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00071.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10/page4185" xml:id="page4185">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-10%2F00072.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-10/00072.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v11.xml
+++ b/TEI編集用/engishiki_v11.xml
@@ -1343,7 +1343,7 @@
   <text>
     <body>
       <div ana="太政官" n="11" type="巻" xml:id="volume11">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai11">
           <p xml:id="shudai1101"> 延喜式巻第十一 </p>
         </div>
@@ -1372,7 +1372,7 @@
               </orgName> 、若大臣不在者、申中納言以上、其事 <anchor xml:id="app1110020102"/> 重 <anchor xml:id="app1110020102e"/>
               者臨時奏裁、自余准例処分、其考選目録及請印六位以下位記者、 <orgName corresp="#中務省"> 中務 </orgName> ・ <orgName corresp="#式部省"> 式部 </orgName> ・
                 <orgName corresp="#兵部省"> 兵部 </orgName> 三省不経 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00004.tif/full/full/0/default.jpg"/>
               弁官直申 <orgName corresp="#太政官"> 太政官 </orgName> 、 <orgName corresp="#中務省"> 中務 </orgName> 申夏冬時服、及 <orgName
                 corresp="#式部省"> 式部 </orgName> 補文学・家令以下傔仗簡 <anchor xml:id="app1110020103"/> 遣 <placeName corresp="#諸国"> 諸国
               </placeName> 使人 <anchor xml:id="app1110020103e"/> 亦直申、 </p>
@@ -1466,7 +1466,7 @@
               弁官牒少納言式 <lb/> 左弁官〈右弁官准此、〉 <lb/> 其国司申送調庸及中男作物等帳若干通 <lb/>
               <orgName corresp="#式部省"> 式部省 </orgName> 申為応給諸司春夏禄事一通 <lb/>
               <orgName corresp="#兵部省"> 兵 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00005.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00005.tif/full/full/0/default.jpg"/>
                 部省 </orgName> 申為同前事一通 <lb/>
               <seg rendition="#indent2"> 右若干通請奏、 </seg>
             </p>
@@ -1506,7 +1506,7 @@
             <head ana="少納言牒式"/>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11100901 engishiki_v11_en.xml#item11100901" xml:id="item11100901"
                 ><anchor xml:id="app1110090101"/><anchor xml:id="app1110090101e"/> 少納言牒弁官式 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00006.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00006.tif/full/full/0/default.jpg"/>
               其国司申送調庸及中男作物等帳若干通 <lb/>
               <orgName corresp="#式部省"> 式部省 </orgName> 申為応給諸司春夏禄事一通 <lb/>
               <orgName corresp="#兵部省"> 兵部省 </orgName> 申為同前事一通 <lb/>
@@ -1543,7 +1543,7 @@
             <p ana="項" corresp="engishiki_v11_ja.xml#item11100905 engishiki_v11_en.xml#item11100905" xml:id="item11100905">
               牒、具件如前、至請検領、故牒、 <lb/>
               <seg rendition="#indent7"> 年月日　外記位姓名牒 </seg><lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00007.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00007.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent7">少納言位姓 <anchor xml:id="app1110090501"/> 名 <anchor xml:id="app1110090501e"/>
               </seg>
             </p>
@@ -1635,7 +1635,7 @@
                 xml:id="app1110110102e"/> 詔書、及預官社神、得度還俗、増減官員、遣駅伝使并下駅鈴、新任国司并諸司在外国者赴任、五位以上出畿外、出納 <orgName corresp="#兵庫寮"> 兵庫
               </orgName> 器仗、用正税、徴免課役、輸調庸物色及賜人官物・〈給 <placeName corresp="#諸国"><anchor xml:id="app1110110103"/> 諸 <anchor
                   xml:id="app1110110103e"/> 国 </placeName> 者内印、給京庫者外印、〉公地・封戸・雑田、遷収穀、百姓附籍・移貫・改姓、蕃 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00008.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00008.tif/full/full/0/default.jpg"/>
               人還国、御馬、廃置郡駅、断罪、禁制、放賤従良等類、並請内印、余皆外印、諸 <orgName corresp="#中務省 #式部省 #治部省 #民部省 #兵部省 #刑部省 #大蔵省 #宮内省"> 省 </orgName>
               請印下 <placeName corresp="#諸国"> 諸国 </placeName> 符亦各准此、〈 <orgName corresp="#民部省"> 民部省 </orgName> 符、 <orgName
                 corresp="#治部省"> 治 <anchor xml:id="app1110110104"/> 部 <anchor xml:id="app1110110104e"/>
@@ -1765,7 +1765,7 @@
               <note> 転　土本等「伝」。九本、京博本朱傍書により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00009.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00009.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111020 engishiki_v11_en.xml#article111020" n="11.20" type="条"
             xml:id="article111020">
             <head ana="二員秩満"/>
@@ -1864,7 +1864,7 @@
               <note> 請改印　土本「改」無く、また細字注とする。近本等、本文とするも同じく「改」無し。九本により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00010.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00010.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111028 engishiki_v11_en.xml#article111028" n="11.28" type="条"
             xml:id="article111028">
             <head ana="毀内印"/>
@@ -1991,7 +1991,7 @@
             <p ana="項" corresp="engishiki_v11_ja.xml#item11103401 engishiki_v11_en.xml#item11103401" xml:id="item11103401"
                 ><anchor xml:id="app1110340101"/><anchor xml:id="app1110340101e"/> 凡 <placeName corresp="#諸国"> 諸国
               </placeName> 雑米有未進者、返却其官長解由、知無 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00011.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00011.tif/full/full/0/default.jpg"/>
               未進、然後令下、 </p>
             <app from="#app1110340101" to="#app1110340101e" type="標注">
               <lem> 貞 </lem>
@@ -2062,7 +2062,7 @@
             <p ana="項" corresp="engishiki_v11_ja.xml#item11104001 engishiki_v11_en.xml#item11104001" xml:id="item11104001"
                 ><anchor xml:id="app1110400101"/><anchor xml:id="app1110400101e"/> 凡四天王・東・西并梵釈寺等惣用帳、停送綱所、令進弁官、文殿 <anchor
                 xml:id="app1110400102"/> 預 <anchor xml:id="app1110400102e"/> 史生勘署、別当史更亦覆勘 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00012.tif/full/full/0/default.jpg"/>
               後加署、進帳之後早令計会、若有闕怠不進帳者、勘責寺家、 </p>
             <app from="#app1110400101" to="#app1110400101e" type="標注">
               <lem wit="#近本 #壬本"> 延 </lem>
@@ -2135,7 +2135,7 @@
             <p ana="項" corresp="engishiki_v11_ja.xml#item11104601 engishiki_v11_en.xml#item11104601" xml:id="item11104601">
               凡遣 <placeName corresp="#和泉国"> 和泉国 </placeName> 使、准外国給駅鈴、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00013.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00013.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111047 engishiki_v11_en.xml#article111047" n="11.47" type="条"
             xml:id="article111047">
             <head ana="遣諸国使"/>
@@ -2234,7 +2234,7 @@
               <note> 先申障　土本等弥書。壬本・京博本書入に従い、衍と見て削る。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00014.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00014.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111054 engishiki_v11_en.xml#article111054" n="11.54" type="条"
             xml:id="article111054">
             <head ana="登庫検校"/>
@@ -2301,7 +2301,7 @@
               <note> 弘延　土本無し。近本・壬本等により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00015.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00015.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111060 engishiki_v11_en.xml#article111060" n="11.60" type="条"
             xml:id="article111060">
             <head ana="召使任官"/>
@@ -2451,7 +2451,7 @@
               <note> 弁官　九本・慶長本無し。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00016.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00016.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111070 engishiki_v11_en.xml#article111070" n="11.70" type="条"
             xml:id="article111070">
             <head ana="松尾祭"/>
@@ -2560,7 +2560,7 @@
                 corresp="#神祇官"> 神祇官 </orgName>
               <anchor xml:id="app1110740104"/> 下 <anchor xml:id="app1110740104e"/> 、〈事見 <orgName corresp="#宮内省"> 宮内
               </orgName> 式、〉訖各帰舎沐浴、晡後入内供奉其 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00017.tif/full/full/0/default.jpg"/>
               事、 </p>
             <app from="#app1110740101" to="#app1110740101e" type="標注">
               <lem> 弘貞延 </lem>
@@ -2675,7 +2675,7 @@
               <lem> 延 </lem>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00018.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00018.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111081 engishiki_v11_en.xml#article111081" n="11.81" type="条"
             xml:id="article111081">
             <head ana="会参上日条"/>
@@ -2747,7 +2747,7 @@
               卜定愈紀・主基国郡、〈並封卜之、〉奏可訖即下知、依例准擬、又定検校・行事、 </p>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11108502 engishiki_v11_en.xml#item11108502" xml:id="item11108502">
               八月遣使両国、卜抜穂田及斎場雑 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00019.tif/full/full/0/default.jpg"/>
               色人令行事、并仰 <placeName corresp="#諸国"> 諸国 </placeName> 造供神器、九月造斎場織神服備供神物、十月遣 <placeName corresp="#諸国"> 諸国
               </placeName> 大祓、及差奉幣使発遣、即天皇臨幸川上為禊、十一月為散斎月、〈自朔至晦、〉月内致斎 <anchor xml:id="app1110850201"/> 三 <anchor
                 xml:id="app1110850201e"/> 日、〈自丑至卯、〉 <anchor xml:id="app1110850202"/> 前 <anchor xml:id="app1110850202e"/>
@@ -2764,7 +2764,7 @@
               巳日薦御膳給饗、奏国風並同辰日、但亦奏和舞・ <anchor xml:id="app1110850501"/> 田 <anchor xml:id="app1110850501e"/> 舞、 </p>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11108506 engishiki_v11_en.xml#item11108506" xml:id="item11108506">
               午日召五位已上及六位同前日、叙位両国司及諸氏人等、又奏久米舞・吉志舞并大歌・五節舞、供奉解斎和舞、訖賜禄皇太 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00020.tif/full/full/0/default.jpg"/>
               子已下五位已上有差、又諸司六位已下及両国駈使丁已上給禄、〈諸司六位已下給禄、両国主典已下叙位、 <anchor xml:id="app1110850601"/> 或 <anchor
                 xml:id="app1110850601e"/> 及未日参議一人行事、弁大夫宣命、〉 </p>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11108507 engishiki_v11_en.xml#item11108507" xml:id="item11108507">
@@ -2864,7 +2864,7 @@
                 xml:id="app1110870104e"/> 斎院、臨川上禊潔即入野宮、〈事見斎宮式、〉 </p>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11108702 engishiki_v11_en.xml#item11108702" xml:id="item11108702">
               潔斎三年、五月以前、任 <orgName corresp="#寮"> 斎宮寮 </orgName> 官人及主神司、其諸司七月以前任之、即依例准擬庶事、九月上旬卜定吉日、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00021.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00021.tif/full/full/0/default.jpg"/>
               向伊勢大神宮、預任装束司、五位二人、〈一人 <orgName corresp="#神祇官"> 神祇 </orgName> 副以上、一人左右少弁以上、〉六位以下四人、〈 <orgName corresp="#神祇官"> 神祇 </orgName>
               <anchor xml:id="app1110870201"/> 祐 <anchor xml:id="app1110870201e"/> 、弁官史、 <orgName corresp="#縫殿寮"> 縫殿
               </orgName> 允、諸司主典、〉前行日点定監送使四人、〈参議若中納言一人、弁・史各一人、 <anchor xml:id="app1110870202"/> 六位 <anchor
@@ -3002,7 +3002,7 @@
               <lem> 貞 </lem>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00022.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00022.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111093 engishiki_v11_en.xml#article111093" n="11.93" type="条"
             xml:id="article111093">
             <head ana="朝賀"/>
@@ -3115,7 +3115,7 @@
             <p ana="項" corresp="engishiki_v11_ja.xml#item11109901 engishiki_v11_en.xml#item11109901" xml:id="item11109901"
                 ><anchor xml:id="app1110990101"/><anchor xml:id="app1110990101e"/> 凡正月十七日大射、所司預設御座、弁備庶事、大臣 <anchor
                 xml:id="app1110990102"/> 侍 <anchor xml:id="app1110990102e"/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00023.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00023.tif/full/full/0/default.jpg"/>
               殿上 <anchor xml:id="app1110990103"/> 行事 <anchor xml:id="app1110990103e"/> 如常儀、若諸衛不射畢、十八日遣参議一人行事、〈事見儀式、〉 </p>
             <app from="#app1110990101" to="#app1110990101e" type="標注">
               <lem> 弘 </lem>
@@ -3234,7 +3234,7 @@
               <note> 禄　土本等無し。九本により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00024.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00024.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111107 engishiki_v11_en.xml#article111107" n="11.107" type="条"
             xml:id="article111107">
             <head ana="非侍従見参"/>
@@ -3334,7 +3334,7 @@
                 ><anchor xml:id="app1111110101"/><anchor xml:id="app1111110101e"/> 凡十二月晦日儺者、 <orgName corresp="#中務省"> 中務
               </orgName> 預点親王及大臣已下次侍従已上、分配諸門、丞・録・ <anchor xml:id="app1111110102"/> 内 <anchor xml:id="app1111110102e"/>
               舎人・大舎人等亦同、〈事見 <orgName corresp="#中務省"> 中務 </orgName> 式、〉当 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00025.tif/full/full/0/default.jpg"/>
               日戌時、親王并大臣已下著承明門外東庭幄座、少納言・ <anchor xml:id="app1111110103"/> 弁 <anchor xml:id="app1111110103e"/>
               ・外記・史候之、依例行事、〈事見儀式、〉 </p>
             <app from="#app1111110101" to="#app1111110101e" type="標注">
@@ -3470,7 +3470,7 @@
               <note> 以　九本「已」。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00026.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00026.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111113 engishiki_v11_en.xml#article111113" n="11.113" type="条"
             xml:id="article111113">
             <head ana="季禄"/>
@@ -3614,7 +3614,7 @@
             <head ana="馬料"/>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11111801 engishiki_v11_en.xml#item11111801" xml:id="item11111801"
                 ><anchor xml:id="app1111180101"/><anchor xml:id="app1111180101e"/> 凡諸司馬料者、起正月尽六月、計上日一百廿五以上、給春夏 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00027.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00027.tif/full/full/0/default.jpg"/>
               料、 <orgName corresp="#中務省"> 中務 </orgName> ・ <orgName corresp="#式部省"> 式部 </orgName> ・ <orgName corresp="#兵部省">
                 兵部 </orgName> 等省録人物数、七月十日弁官率三 <orgName corresp="#中務省 #式部省 #兵部省"> 省 </orgName> 、申 <orgName corresp="#太政官"> 太政官
               </orgName> 、〈其 <orgName corresp="#太政官"> 太政官 </orgName> 馬料者、当月一日録送弁官、弁官惣造 <anchor xml:id="app1111180102"/> 目
@@ -3711,7 +3711,7 @@
               考選文者、八月一日少納言・弁・外記・史等別当勘抄成案畢、長上考文、十一日申大臣、 </p>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11112302 engishiki_v11_en.xml#item11112302" xml:id="item11112302">
               其儀、大臣已下就曹司庁、考選史持短冊 <anchor xml:id="app1111230201"/> 筥 <anchor xml:id="app1111230201e"/> 、又史一人持札并紙文、外記 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00028.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00028.tif/full/full/0/default.jpg"/>
               史生一人持丹硯 <anchor xml:id="app1111230202"/> 筥 <anchor xml:id="app1111230202e"/> 、少納言・弁大夫 <anchor
                 xml:id="app1111230203"/> 倶 <anchor xml:id="app1111230203e"/> 率就版位、 </p>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11112303 engishiki_v11_en.xml#item11112303" xml:id="item11112303">
@@ -3738,7 +3738,7 @@
             <p ana="項" corresp="engishiki_v11_ja.xml#item11112307 engishiki_v11_en.xml#item11112307" xml:id="item11112307">
               厨家 <anchor xml:id="app1111230701"/> 儲 <anchor xml:id="app1111230701e"/> 酒饌、次大臣已下史已上謝座着宴座、〈大臣入自北戸、納言已下入自 <anchor
                 xml:id="app1111230702"/> 西 <anchor xml:id="app1111230702e"/> 廊、列立南廂、但六位在堂下、昇自西側階、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00029.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00029.tif/full/full/0/default.jpg"/>
               三献訖参議已上出着東廊、頃之 <anchor xml:id="app1111230703"/> 入自 <anchor xml:id="app1111230703e"/>
               北戸、更着穩座、少納言・弁候南廂、盃觴三巡之後召史生、史生列立庭中、謝座着座、〈其座在西庁東廂、〉次召内記及近辺諸司、〈 <orgName corresp="#中務省"> 中務 </orgName> ・ <orgName
                 corresp="#民部省"> 民部 </orgName> ・ <orgName corresp="#宮内省"> 宮内 </orgName> ・勘解由使等也、其座在西壁下、〉次 <orgName
@@ -3923,7 +3923,7 @@
               <note> 例、其番上　土本等弥書。九本により削る。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00030.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00030.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111127 engishiki_v11_en.xml#article111127" n="11.127" type="条"
             xml:id="article111127">
             <head ana="列見"/>
@@ -4013,7 +4013,7 @@
               <note> 任　土本等「仁」。九本、壬本・京博本朱傍書により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00031.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00031.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111132 engishiki_v11_en.xml#article111132" n="11.132" type="条"
             xml:id="article111132">
             <head ana="出雲国造"/>
@@ -4090,7 +4090,7 @@
               <note> 刑部　訳注本は要略二五（諸陵寮本・史籍集覧本）によりこの下に「省」を補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00032.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00032.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111136 engishiki_v11_en.xml#article111136" n="11.136" type="条"
             xml:id="article111136">
             <head ana="四度公文"/>
@@ -4189,7 +4189,7 @@
               <lem> 弘延 </lem>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00033.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00033.tif/full/full/0/default.jpg"/>
           <div ana="太政官" corresp="engishiki_v11_ja.xml#article111144 engishiki_v11_en.xml#article111144" n="11.144" type="条"
             xml:id="article111144">
             <head ana="文殿公文"/>
@@ -4286,7 +4286,7 @@
             <head ana="年終帳"/>
             <p ana="項" corresp="engishiki_v11_ja.xml#item11115201 engishiki_v11_en.xml#item11115201" xml:id="item11115201"
                 ><anchor xml:id="app1111520101"/><anchor xml:id="app1111520101e"/> 凡諸司年終帳、正月廿一日進之、但被管二月廿一日 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00034.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00034.tif/full/full/0/default.jpg"/>
               其年号下注十二月卅日、並加外題、下勘解由使、 </p>
             <app from="#app1111520101" to="#app1111520101e" type="標注">
               <lem> 貞 </lem>
@@ -4394,114 +4394,114 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-11/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-11">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4186" xml:id="page4186">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4187" xml:id="page4187">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4188" xml:id="page4188">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4189" xml:id="page4189">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4190" xml:id="page4190">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4191" xml:id="page4191">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4192" xml:id="page4192">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4193" xml:id="page4193">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4194" xml:id="page4194">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4195" xml:id="page4195">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4196" xml:id="page4196">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4197" xml:id="page4197">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4198" xml:id="page4198">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4199" xml:id="page4199">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4200" xml:id="page4200">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4201" xml:id="page4201">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4202" xml:id="page4202">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4203" xml:id="page4203">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4204" xml:id="page4204">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4205" xml:id="page4205">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4206" xml:id="page4206">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4207" xml:id="page4207">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4208" xml:id="page4208">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4209" xml:id="page4209">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4210" xml:id="page4210">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4211" xml:id="page4211">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4212" xml:id="page4212">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4213" xml:id="page4213">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4214" xml:id="page4214">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4215" xml:id="page4215">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4216" xml:id="page4216">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4217" xml:id="page4217">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4218" xml:id="page4218">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4219" xml:id="page4219">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4220" xml:id="page4220">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11/page4221" xml:id="page4221">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-11%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-11/00036.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v14.xml
+++ b/TEI編集用/engishiki_v14.xml
@@ -1363,7 +1363,7 @@
   <text>
     <body>
       <div ana="縫殿" n="14" type="巻" xml:id="volume14">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai14">
           <p xml:id="shudai1401"> 延喜式巻第十四 </p>
         </div>
@@ -1385,7 +1385,7 @@
             <p ana="項" corresp="engishiki_v14_ja.xml#item14100102 engishiki_v14_en.xml#item14100102" xml:id="item14100102"
                 ><orgName corresp="#縫殿寮"> 縫殿 </orgName> 神一座 <lb/>
               <anchor xml:id="app1410010201"/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00003.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00003.tif/full/full/0/default.jpg"/>
               木綿 <anchor xml:id="app1410010201e"/> 大八両、酒二斗、米・糯米各一斗、大豆・小豆各五升、鰒五斤、腊・乾魚・海藻各六斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14100103 engishiki_v14_en.xml#item14100103" xml:id="item14100103">
               着酒神一座 <lb/> 五色薄絁各二尺、木綿大一斤、鮮物、〈直、〉酒四斗、米三斗、糯米一斗、大豆・小豆各五升、鰒五斤、腊・乾魚・海藻各六斤、物忌童女装束絹一疋、〈夏料、〉紫絹三丈、調綿二屯、〈冬料、〉 <lb/>
@@ -1413,7 +1413,7 @@
                 <anchor xml:id="app1410020101e"/> 、〉綿五屯、〈別二屯半、〉敷被一条、〈一疋、〉褥二条、〈別帛三丈、暴布二丈一尺、席一 <anchor xml:id="app1410020102"/>
               枚 <anchor xml:id="app1410020102e"/> 、〉帛帷二条、〈別三丈七尺、〉暴布軾一枚、〈一端、〉唾巾一条、〈一端、〉帛袜二両、〈別三尺五寸、〉練糸二両一分、生糸二分、櫛二枚、履一両、〈已上二種、
                 <orgName corresp="#内蔵寮"> 内蔵 </orgName> 弁備、余条櫛・履准此、〉牀帊帛二条、〈別四丈六尺、〉納服白木韓櫃二合、敷細布二条、〈別五尺、〉暴布綱二条、〈別長二丈、〉黒 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00004.tif/full/full/0/default.jpg"/>
               葛筥二合、〈各長一尺五寸、広一尺三寸、〉紙十張、祓麻大一両、〈並事訖付 <orgName corresp="#神祇官"> 神祇 <anchor xml:id="app1410020103"/> 官 <anchor
                   xml:id="app1410020103e"/>
               </orgName> 、〉紅花大三両二分、支子一斗四升、酢三合六夕、薪百廿斤、藁六囲半、 </p>
@@ -1476,7 +1476,7 @@
             <p ana="項" corresp="engishiki_v14_ja.xml#item14100501 engishiki_v14_en.xml#item14100501" xml:id="item14100501">
               新嘗会御服 <lb/> 帛袍二領、〈別一疋一丈五尺、〉綿六屯、〈 <anchor xml:id="app1410050101"/> 別三屯 <anchor xml:id="app1410050101e"/>
               、〉襖子二領、〈別一疋八尺五寸、〉綿六屯、〈別三屯、〉汗衫二領、〈別三丈七尺五寸、〉袴二腰、中袴二 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00005.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00005.tif/full/full/0/default.jpg"/>
               腰、綿六屯、褌二腰、被二条、綿卅屯、敷被一条、綿廿屯、褥一条、綿十屯、帛帷二条、帛坂枕一 <anchor xml:id="app1410050102"/> 枚 <anchor xml:id="app1410050102e"
               /> 、〈一 <anchor xml:id="app1410050103"/> 折 <anchor xml:id="app1410050103e"/>
               四尺、〉暴布軾一枚、唾巾一条、帛袜二両、綿一屯、帯二条、〈別五尺五寸、〉練糸二両三分、生糸一分三銖、櫛二枚、履一両、 <anchor xml:id="app1410050104"/> 牀 <anchor
@@ -1514,7 +1514,7 @@
                 <anchor xml:id="app1410060101"/> 猴 <anchor xml:id="app1410060101e"/>
               女四人、緑袍四領、〈緑表、帛裏、別三丈、〉綿八屯、〈別二屯、〉両面紐四条、〈別長一尺九寸、広五寸、〉汗衫四領、〈別三丈、〉緑裙四腰、〈緑表、帛裏、別三丈、〉裙腰料縹帛四条、〈別一丈五尺、〉綿八屯、〈別二屯、〉下裙四腰、〈裙別三丈、腰別一丈五尺、〉袴四腰、〈別三丈、〉綿四屯、〈別一屯、〉縹帯四条、〈別長六尺、広四寸五分、〉細布髪髻四条、〈別二尺、〉緋
                 <anchor xml:id="app1410060102"/> 帔 <anchor xml:id="app1410060102e"/> 四条、〈緋表、帛裏、別一丈五尺、〉細布袜四両、〈別三尺、〉線鞋四 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00006.tif/full/full/0/default.jpg"/>
               両、 </p>
             <app from="#app1410060101" to="#app1410060101e">
               <lem wit="#剛本 #壬本"> 猴 </lem>
@@ -1584,7 +1584,7 @@
               <note> 官　土本「宮」。剛本・近本等により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00007.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00007.tif/full/full/0/default.jpg"/>
           <div ana="縫殿" corresp="engishiki_v14_ja.xml#article141008 engishiki_v14_en.xml#article141008" n="14.8" type="条"
             xml:id="article141008">
             <head ana="衆僧法服"/>
@@ -1603,7 +1603,7 @@
                 xml:id="app1410080110e"/> 張、〈雑用、〉 <lb/>
               <seg rendition="#indent"> 右、法服依前件、若応縫九条者、用帛一疋一丈二尺二寸〈袈裟 <anchor xml:id="app1410080111"/> 料 <anchor
                   xml:id="app1410080111e"/> 三丈九尺六寸、甲料三丈二尺六寸、〉・糸五両、五条用帛四 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00008.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00008.tif/full/full/0/default.jpg"/>
                 丈二尺四寸〈袈裟 <anchor xml:id="app1410080112"/> 料 <anchor xml:id="app1410080112e"/> 二丈二尺、甲料二丈四寸、〉・糸四両、其縫備所充席四枚、
               </seg>
             </p>
@@ -1692,7 +1692,7 @@
                 xml:id="app1410090103"/> 四 <anchor xml:id="app1410090103e"/> 銖、〉袷褌・単褌各十腰料絹十一疋二丈、〈袷別四丈、単別二丈、腰料八尺、〉 <anchor
                 xml:id="app1410090104"/> 糸二両三銖、〈別五銖、〉 <anchor xml:id="app1410090104e"/>
               被衣八領〈白四領、紅四領、三月減二領、〉料絹十二疋、〈別一疋三丈、〉綿六十四屯、〈別八屯、〉糸一両一分二銖、〈別四銖、〉被十二条〈並紅、三月減四条、〉料絹廿四疋、〈別二疋、〉綿一百廿屯、〈別十屯、〉糸三両、〈別一分、〉褥四条〈並白、〉料絹六疋五丈六尺、〈別一疋四丈四尺、〉綿廿屯、〈別五屯、〉糸二分、〈別三銖、〉襪絁一疋、 </p>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00009.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00009.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14100902 engishiki_v14_en.xml#item14100902" xml:id="item14100902">
               夏季 <lb/> 四月料、着襴縠衫六領〈白橡四領、藍薄色二領、九月一領、用白、〉料縠七疋二丈六尺、〈別五丈一尺、〉糸一両、〈別四銖、〉半臂十領〈紫五領、藍 <anchor xml:id="app1410090201"/>
               五 <anchor xml:id="app1410090201e"/>
@@ -1703,7 +1703,7 @@
               六月料、着襴縠衫六領、〈白一領、七月不須、〉半臂十領、汗衫十領、単𧜣十領、表袴・中袴・袷褌・単褌各十腰、被二条、〈並紅、〉褥六条、〈並白、〉襪絁一疋、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14100903 engishiki_v14_en.xml#item14100903" xml:id="item14100903">
               秋季 <lb/> 七月料同六月、八月同五月、九月同四月、 <lb/> 冬季 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00010.tif/full/full/0/default.jpg"/>
               <lb/> 十月料同三月、十一月・十二月並同正月、 </p>
             <app from="#app1410090101" to="#app1410090101e">
               <lem wit="#土本 #剛本朱傍書"> 淡 </lem>
@@ -1758,7 +1758,7 @@
                 <anchor xml:id="app1410100104"/> 五寸 <anchor xml:id="app1410100104e"/> 、〈袷別一疋一丈五尺、単別三丈七尺 <anchor
                 xml:id="app1410100105"/> 五寸 <anchor xml:id="app1410100105e"/>
               、〉綿廿四屯、〈別八屯、〉糸二分、〈別四銖、〉被六条〈三月減二条、〉料絹十一疋二尺四寸、〈別一疋五丈四寸、〉綿六十屯、〈別十屯、〉糸一両二分、〈別一分、〉褥三条料絹五疋、〈別一疋四丈、〉綿十五屯、〈別五屯、〉糸一分三銖、〈別三銖、〉御匣殿料絹十疋、綿卅屯、 </p>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00011.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00011.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101002 engishiki_v14_en.xml#item14101002" xml:id="item14101002">
               夏季 <lb/>
               四月料、〈五月・六月同七月、〉袍十領、〈白一領、作目白橡九領、〉袷袍六領〈藍并朽葉之類、〉料絹五疋、〈別五丈、〉糸一両二分、〈別一分、〉単衣十領、〈白一領、韓紅三領、蘇芳四領、藍二領、〉領巾四条、羅裙二腰〈白一腰、夾纈并作目摺一腰、〉料羅一疋五尺、〈別三丈二尺五寸、〉糸一分二銖、〈別四銖、〉同腰料絹一丈、〈別五尺、〉
@@ -1770,7 +1770,7 @@
               秋季 <lb/> 七月料、〈八月亦同、九月同四月、〉単衣卌領、〈白三領、蘇芳十七領、韓紅十領、藍十領、〉領巾四条、羅裙二腰、 <anchor xml:id="app1410100301"/> 同 <anchor
                 xml:id="app1410100301e"/>
               腰料絹一丈、紗裙二腰、同腰料絹一丈、下裙四腰、同腰料絹二丈、袴十五腰、単袴廿腰、袿衣・単袿衣各二領、綿十屯、〈別五屯、〉被二条、綿十二屯、〈別六屯、〉褥三条、御匣殿料絹十疋、綿卅屯、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00012.tif/full/full/0/default.jpg"/>
               <lb/> 冬季 <lb/> 十月料同三月、十一月・十二月並同正月、 <lb/>
               <seg rendition="#indent"> 右、四季御服、並依前件、毎 <anchor xml:id="app1410100302"/> 季 <anchor xml:id="app1410100302e"/>
                 依数、従 <orgName corresp="#内蔵寮"> 内蔵寮 </orgName> 受之、准例染縫、〈臨時定色、〉月別一日・十六日両般均分供進、若数不等者、上般加之、 </seg>
@@ -1845,12 +1845,12 @@
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101201 engishiki_v14_en.xml#item14101201" xml:id="item14101201">
               裁縫功程 <lb/> 九条袈裟、長功日五人、中功 <anchor xml:id="app1410120101"/> 日 <anchor xml:id="app1410120101e"/>
               六人、短功日七人、七条、長功日三人、中功日四人、短功日五人、五条、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00013.tif/full/full/0/default.jpg"/>
               長功日一人半、中功日二人、短功日三人、 <anchor xml:id="app1410120102"/> 蔭脊 <anchor xml:id="app1410120102e"/>
               、〈座具并裳亦同、〉長功日大半人、中功日一人、短功日一人大半、袍、〈襖子及女袍・褥六幅、四幅被准此、〉長功日大半、中功日一人、短功日二人、単衣、〈汗衫亦同、但雑給料各減小半人、〉長功日一人小半、中功日一人大半、短功日三人、綿袴、〈褌及女袴亦同、〉長功日
                 <anchor xml:id="app1410120103"/> 小 <anchor xml:id="app1410120103e"/>
               半、中功日大半、短功日一人、表袷裙、長功日三人、中功日四人、短功日五人、単裙、〈襪亦同、〉長功日四腰、中功日三腰、短功日二腰、布袍、長功日三領、中功日二領、短功日一領、布衫、長功日六領、中功日四領、短功日三領、単布袴、長功日八腰、中功日六腰、短功日五腰、八尺斗帳一具、〈七尺亦准此、〉長功日十三人、中功日十五人、短功日廿人、新羅組一条、〈長一丈、余組准此、〉糸二絇八両、長功日廿八人、中功日卅二人、短功日六十八人、絞組一条、糸一絇四両、長功日十四人、中功日十六人、短功日廿人、
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00014.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00014.tif/full/full/0/default.jpg"
               /> 大 <anchor xml:id="app1410120104"/> 丸 <anchor xml:id="app1410120104e"/>
               組一条、糸五両、〈中丸組減半、細組減四分之三、〉長功日大半、中功日一人小半、短功日二人、綺一条、〈長五丈、広三分、〉糸五両、長功日六人、中功日八人、短功日十人、二目纈帛一疋、〈一目纈減半、〉長功日十四人、中功日十七人、短功日廿人、榛摺帛一疋、長功日大半、中功日一人小半、短功日二人、青摺布一端、長功日
                 <anchor xml:id="app1410120105"/> 少 <anchor xml:id="app1410120105e"/> 半、中功日大半、短功日一人、 </p>
@@ -1891,7 +1891,7 @@
               雑染用度 <lb/> 黄櫨綾一疋、櫨十四斤、蘇芳十一斤、酢二升、灰三斛、薪八荷、帛一疋、紫 <anchor xml:id="app1410130101"/> 草 <anchor
                 xml:id="app1410130101e"/> 十五斤、酢一升、灰一斛、薪四荷、 <lb/>
               黄丹綾一疋、紅花大十斤八両、支子一斗二升、酢一斗、麸五升、藁四囲、薪一百八十斤、〈准生木所定、余皆准此、〉帛一疋、紅花大七斤、支子九升、酢七升、麸四升、藁三囲、薪一百廿斤、羅一疋、〈用度同帛、〉糸一絇、紅花大二斤八両、支子三升、酢二
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00015.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00015.tif/full/full/0/default.jpg"
               /> 升三合、麸二升、藁一囲、薪六十斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101302 engishiki_v14_en.xml#item14101302" xml:id="item14101302">
               深紫綾一疋、〈綿紬・糸紬・東絁亦同、〉紫草卅斤、酢二升、灰二 <anchor xml:id="app1410130201"/> 石 <anchor xml:id="app1410130201e"/>
@@ -1900,7 +1900,7 @@
               浅紫綾一疋、〈綿紬・糸紬・東絁亦同、〉紫草五斤、酢二升、灰五斗、薪六十斤、帛一疋、紫草五斤、酢一升五合、灰五斗、薪六十斤、羅一疋、〈用度同帛、〉絞紗一疋、紫草五斤、酢六合、灰一斗二升、薪六十斤、纈帛一疋、紫草五斤、酢一升、灰二斗五升、薪六十斤、糸一絇、紫草五斤、酢三合、灰一斗、薪
                 <anchor xml:id="app1410130202"/> 三十 <anchor xml:id="app1410130202e"/>
               斤、貲布一端、紫草七斤、酢八合、灰一斗八升、薪六十斤、葛布一端、紫草七斤、酢六合、灰一斗五 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00016.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00016.tif/full/full/0/default.jpg"/>
               升、薪六十斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101303 engishiki_v14_en.xml#item14101303" xml:id="item14101303"
                 ><anchor xml:id="app1410130301"/> 深滅紫 <anchor xml:id="app1410130301e"/>
@@ -1912,7 +1912,7 @@
               、灰三石、薪八百卌斤、帛一疋、茜大廿五斤、紫草廿三斤、米四升、灰二石、薪六百斤、貲布一端、〈四丈、〉茜大十六斤、紫草十四斤、米三升、灰一石五 <anchor xml:id="app1410130402"/> 斗
                 <anchor xml:id="app1410130402e"/> 、薪三百六十斤、葛布一端、茜大七斤、米八合、灰四斗、薪九十斤、紫草七斤、 <lb/> 浅緋綾一疋、〈綿紬・ <anchor
                 xml:id="app1410130403"/> 東絁 <anchor xml:id="app1410130403e"/> ・貲布亦同、〉茜大卅斤、米五升、灰二石、薪三百六十斤、帛一疋、茜大廿五斤、米四升、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00017.tif/full/full/0/default.jpg"/>
               灰二石、薪三百六十斤、葛布一端、茜大十斤、米一升、灰四斗、薪九十斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101305 engishiki_v14_en.xml#item14101305" xml:id="item14101305">
               深蘇芳綾一疋、蘇芳大一斤、酢八合、灰三斗、薪一百廿斤、帛一疋、蘇芳大十両、酢七合、灰二斗、薪六十斤、纈帛一疋、蘇芳大十両、酢七合、灰二斗、薪六十斤、糸一絇、蘇芳小十三両、酢二合、灰六斗、薪廿斤、 <lb/>
@@ -1922,13 +1922,13 @@
               葡萄綾一疋、紫草三斤、酢一合、灰四升、薪卌斤、帛一疋、紫草一斤、酢一合、灰二升、薪廿斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101306 engishiki_v14_en.xml#item14101306" xml:id="item14101306">
               韓紅花綾一疋、紅花大十斤、酢一斗、麸一斗、藁 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00018.tif/full/full/0/default.jpg"/>
               三囲、薪一百八十斤、帛一疋、紅花大六斤、酢六升、麸六升、藁二囲、薪一百廿斤、羅一疋、紅花大七斤、酢七升、麩五升、藁二囲半、薪一百五十斤、紗一疋、紅花大二斤、酢二升、麸二升、藁大半囲、薪卌斤、糸一絇、紅花大一斤、酢七合、麸二升、藁半囲、薪卅斤、貲布一端、紅花大四斤、酢一升二合、藁一囲、薪六十斤、細布一端、紅花大五斤、酢六升、藁二囲、薪百五十斤、調布准此、
               <lb/> 中紅花貲布一端、紅花大一斤四両、酢八合、藁一囲、薪卌斤、 <lb/> 退紅帛一疋、紅花小八両、酢一合、藁半囲、薪卅斤、糸一絇、紅花小二両二分、酢三夕、藁小半囲、薪廿斤、細布一端、紅花 <anchor
                 xml:id="app1410130601"/> 大 <anchor xml:id="app1410130601e"/> 四両、酢二合、藁半囲、薪卅斤、調布一端、紅花小十四両、酢一合六夕、藁半囲、薪卅斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101307 engishiki_v14_en.xml#item14101307" xml:id="item14101307">
               深支子綾一疋、紅花大十二両、支子一斗、酢五合、藁半囲、薪卅斤、帛一疋、紅花大八両、支子七升、酢四合、藁半囲、薪卅斤、糸一絇、紅花小一斤、支子 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00019.tif/full/full/0/default.jpg"/>
               三升、酢一合五夕、藁小半囲、薪廿斤、 <lb/> 黄支子綾一疋、支子一斗、薪卅斤、帛一疋、支子八升、薪廿斤、糸一絇、支子三升、薪廿斤、 <lb/>
               浅支子綾一疋、支子二升、紅花小三両、酢一合、藁半囲、薪卅斤、帛一疋、支子三升、紅花小 <anchor xml:id="app1410130701"/> 三 <anchor xml:id="app1410130701e"/>
               両、酢八夕、藁小半囲、薪六斤、糸一絇、支子七合、紅花小一両、酢五夕、藁小半囲、薪三斤、 </p>
@@ -1936,7 +1936,7 @@
               橡綾一疋、〈東絁亦同、〉搗橡二斗五升、茜大二斤、灰七升、薪二百廿斤、帛一疋、搗橡一斗五升、茜大二斤、灰五升、薪二百廿斤、糸一絇、搗橡六升、茜大六両、灰二升、薪卅斤、 <lb/>
               赤白橡綾一疋、〈綿紬・糸紬・東絁亦同、〉黄櫨大九十斤、灰三石、茜大七斤、薪七百廿斤、帛一疋、黄櫨大七十斤、茜大五斤、灰二石、薪六百斤、糸一絇、黄櫨大五斤、灰一斗三升、茜大五両、薪卅斤、貲布一端、黄櫨大十五斤、灰三斗五升、茜大一斤八両、薪一百廿斤、
               <lb/> 青白橡綾一疋、〈綿紬・糸紬・東絁亦同、〉苅安草大九十六斤、紫草六斤、灰三石、薪八百卌斤、帛一疋、苅安草 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00020.tif/full/full/0/default.jpg"/>
               大七十二斤、紫草四斤、灰二石、薪六百六 <anchor xml:id="app1410130801"/> 十 <anchor xml:id="app1410130801e"/>
               斤、糸一絇、苅安草大二斤、紫草一斤、灰七升、薪廿斤、貲布一端、苅安草大卌八斤、紫草五斤、灰一石一斗、薪六十斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101309 engishiki_v14_en.xml#item14101309" xml:id="item14101309">
@@ -1947,7 +1947,7 @@
               青浅緑糸一絇、〈黄浅緑糸亦同、〉藍小半囲、黄蘗八両、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101310 engishiki_v14_en.xml#item14101310" xml:id="item14101310">
               深縹綾一疋、藍十囲、薪六十斤、帛一疋、藍十囲、薪一百廿斤、糸一絇、藍四囲、薪卌斤、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00021.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00021.tif/full/full/0/default.jpg"/>
               貲布一端、乾藍二斗、灰一斗、薪卅斤、 <lb/> 中縹綾一疋、藍七囲、薪九十斤、帛一疋、藍五囲、薪六十斤、糸一絇、藍二囲、薪卅斤、 <lb/> 次縹帛一疋、藍四囲、薪六十斤、糸一絇、藍一囲大半、薪廿斤、 <lb/>
               浅縹綾一疋、藍一囲、薪卅斤、帛一疋、藍半囲、薪卅斤、糸一絇、藍大半囲、薪廿斤、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101311 engishiki_v14_en.xml#item14101311" xml:id="item14101311">
@@ -1955,7 +1955,7 @@
               浅藍色綾一疋、藍半囲、黄蘗八両、帛一疋、藍半囲、黄蘗八両、纈帛一疋、藍半囲、黄蘗八両、糸一絇、藍小半囲、黄蘗八両、 <lb/> 白藍色糸一絇、藍小半囲、黄蘗七両、 </p>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101312 engishiki_v14_en.xml#item14101312" xml:id="item14101312">
               深黄綾一疋、〈綿紬・糸紬・東絁亦同、〉苅安草大五斤、灰一斗五升、薪六十斤、帛一疋、苅安草大三斤、灰八升、薪卅斤、糸一絇、苅安草大一斤、灰三斗、薪廿斤、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00022.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00022.tif/full/full/0/default.jpg"/>
               <lb/> 浅黄綾一疋、〈綿紬・糸紬・東絁亦同、〉苅安草大三斤八両、灰一斗二升、薪卅斤、帛一疋、苅安草大二斤、糸一絇、苅安草大十一両、灰二升、薪廿斤、 </p>
             <app from="#app1410130101" to="#app1410130101e">
               <lem cause="意補" wit="#貞享本"> 草 </lem>
@@ -2085,7 +2085,7 @@
             <head ana="三年雑物"/>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101601 engishiki_v14_en.xml#item14101601" xml:id="item14101601">
               三年一度雑物 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00023.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00023.tif/full/full/0/default.jpg"/>
               <lb/>
               黄絁四丈八尺、帛五疋、緋両面一疋一丈六尺、生絁二疋五丈二尺、調綿十二屯、暴布八端、緋油絁四丈八尺六寸、貲布九端五丈四尺、糸十両、白木脚別机二前、〈各長三尺五寸、高三尺、〉筥三合、〈各方二尺、〉裁板三枚、〈各長五尺、広二尺五寸、厚三寸、〉 <lb/>
               <seg rendition="#indent"> 右、御服所雑物依前件、 </seg>
@@ -2101,7 +2101,7 @@
               覆三条料緋油絁五丈七尺、〈裏料生絹、長同表、〉緋綱六条〈各長二丈、〉料緋絁一疋、調布一端二丈、〈中子料、〉黄覆一条〈長八尺、三幅、〉料黄絁二丈四尺、〈裏料帛、長同表、〉雨覆一条〈長同上、〉料緋油絁二丈四尺、〈裏料生絹、長同表、〉同覆帯四条〈各長八尺、〉料縹絁八尺、〈
                 <anchor xml:id="app1410160302"/> 割 <anchor xml:id="app1410160302e"/>
               四、〉柳筥二合、黒葛筥四合、〈各方三尺、〉筥覆四条〈二条黄絁、二条油絁、〉表料黄絁二丈四尺、緋油絁二丈四尺、裏料帛二丈 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00024.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00024.tif/full/full/0/default.jpg"/>
               四尺、生絹二丈四尺、帷七条〈御衣床并御衣韓櫃等覆料、〉料帛三疋三丈八尺、東絁二疋、〈襷襅料、〉練糸五両、〈縫糸料、〉裁板二枚、〈各長四尺、広二尺、〉瑩板二枚、〈各長三尺五寸、広二尺四寸、〉熨斗二口、熨炭卅六 <anchor
                 xml:id="app1410160303"/> 斛 <anchor xml:id="app1410160303e"/> 、〈請 <orgName corresp="#主殿寮"> 主殿寮 </orgName>
               、〉擣衣料調布二端二丈四尺五寸、下纏料調綿一屯、席二枚、染槽六隻、漆手洗四口、〈 <anchor xml:id="app1410160304"/> 受 <anchor xml:id="app1410160304e"/>
@@ -2159,7 +2159,7 @@
             <head ana="鷹飼"/>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14101901 engishiki_v14_en.xml#item14101901" xml:id="item14101901">
               行幸供奉飼鷹胡桃衫 <anchor xml:id="app1410190101"/> 料 <anchor xml:id="app1410190101e"/> 細布、人別二丈 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00025.tif/full/full/0/default.jpg"/>
               一尺、袴別八尺、袴緒料帛、以八尺充五腰、〈 <anchor xml:id="app1410190102"/> 割 <anchor xml:id="app1410190102e"/> 五、〉飼犬人別押帽子一口、〈別
                 <anchor xml:id="app1410190103"/> 紺細布 <anchor xml:id="app1410190103e"/>
               一尺、〉紺布衫一丈八尺、袴七尺五寸、縫縹糸五銖、〈衫別三銖、袴別二銖、〉並毎年七月内縫備進内裏、〈其数臨時定之、〉 </p>
@@ -2247,7 +2247,7 @@
             <head ana="今良服米"/>
             <p ana="項" corresp="engishiki_v14_ja.xml#item14102801 engishiki_v14_en.xml#item14102801" xml:id="item14102801"> 凡
                 <orgName corresp="#縫殿寮"> 寮 </orgName> 直今良廿四人、〈男二人、女廿二人、〉其衣服并粮米、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00026.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00026.tif/full/full/0/default.jpg"/>
               不経 <orgName corresp="#主殿寮"> 主殿寮 </orgName> 、 <orgName corresp="#縫殿寮"><anchor xml:id="app1410280101"/> 寮 <anchor
                   xml:id="app1410280101e"/>
               </orgName> 直受充、 </p>
@@ -2304,87 +2304,87 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-14/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-14">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4308" xml:id="page4308">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4309" xml:id="page4309">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4310" xml:id="page4310">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4311" xml:id="page4311">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4312" xml:id="page4312">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4313" xml:id="page4313">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4314" xml:id="page4314">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4315" xml:id="page4315">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4316" xml:id="page4316">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4317" xml:id="page4317">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4318" xml:id="page4318">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4319" xml:id="page4319">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4320" xml:id="page4320">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4321" xml:id="page4321">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4322" xml:id="page4322">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4323" xml:id="page4323">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4324" xml:id="page4324">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4325" xml:id="page4325">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4326" xml:id="page4326">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4327" xml:id="page4327">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4328" xml:id="page4328">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4329" xml:id="page4329">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4330" xml:id="page4330">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4331" xml:id="page4331">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4332" xml:id="page4332">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4333" xml:id="page4333">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14/page4334" xml:id="page4334">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-14%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-14/00027.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v17.xml
+++ b/TEI編集用/engishiki_v17.xml
@@ -1364,7 +1364,7 @@
   <text>
     <body>
       <div ana="内匠" n="17" type="巻" xml:id="volume17">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai17">
           <p xml:id="shudai1701"> 延喜式巻第十七 </p>
         </div>
@@ -1385,7 +1385,7 @@
                 xml:id="app1710010103e"/> 、〉 又整立南庭白銅大火炉二口、〈備台、 <anchor xml:id="app1710010104"/> 入 <anchor
                 xml:id="app1710010104e"/> 鉄火袋、〉中階以南相去十丈、東西之間相去六丈、又建烏像・宝幢等之処差向工一人、其蕃客朝参之時亦同、元日 <anchor xml:id="app1710010105"
               /> 御座 <anchor xml:id="app1710010105e"/> 飾物収 <orgName corresp="#内蔵寮"> 内蔵寮 </orgName> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00003.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00003.tif/full/full/0/default.jpg"/>
               当時出用、幔台及火炉収 <orgName corresp="#内匠寮"> 寮 </orgName> 、 </p>
             <app from="#app1710010101" to="#app1710010101e" type="標注">
               <lem wit="#壬本 #京博本"> 弘イ貞イ </lem>
@@ -1481,7 +1481,7 @@
               <rdg wit="#土本 #近本"/>
               <note> 弘貞イ　土本無し。壬本・京博本等による。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00004.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00004.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17100502 engishiki_v17_en.xml#item17100502" xml:id="item17100502"
                 ><anchor xml:id="app1710050201"/><anchor xml:id="app1710050201e"/>
               酒壺一合〈受一斗五升、〉料、銀大七斤八両、炭二石、和炭七斛五斗、油八合六夕、長功卅四人、〈火工十二人、轆轤六人、磨四人、夫十二人、〉 中功卅九人、〈工廿六人、夫十三人、〉短功卌三人、〈工廿九人、夫十四人、〉 </p>
@@ -1550,7 +1550,7 @@
               漆供御雑器 <lb/>
               <anchor xml:id="app1710060101"/>
               <anchor xml:id="app1710060101e"/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00005.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00005.tif/full/full/0/default.jpg"/>
               膳櫃一合、〈長三尺三寸、深八寸五分、広二尺三寸、〉下案一脚、〈長五尺四寸、広二尺四寸、高一尺七寸、〉並塗赤漆料、漆一升二合、荏油四合、綿六両、絁・布各一尺二寸、炭一斗五升、功六人半、 </p>
             <app from="#app1710060101" to="#app1710060101e" type="標注">
               <lem wit="#壬本 #京博本"> 弘 </lem>
@@ -1602,7 +1602,7 @@
               <rdg wit="#土本 #近本"/>
               <note> 弘　土本無し。壬本・京博本等による。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00006.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00006.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17100608 engishiki_v17_en.xml#item17100608" xml:id="item17100608"
                 ><anchor xml:id="app1710060801"/><anchor xml:id="app1710060801e"/> 窪 <anchor xml:id="app1710060802"/> 杯
                 <anchor xml:id="app1710060802e"/> 一口〈径五寸、深一寸五分、〉料、漆七夕、貲布三寸、掃墨二夕、功小半人、 </p>
@@ -1641,7 +1641,7 @@
               八尺台盤台一脚〈長七尺六分、広二尺五寸七分、高一尺五寸五分、〉料、漆五升、絹一尺五寸、布二尺、綿一斤十両、掃墨一升、油二合、細布五尺、〈黏料、〉伊予砥・青砥各小半顆、炭五斗、単功廿五人、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17100704 engishiki_v17_en.xml#item17100704" xml:id="item17100704">
               四尺台盤台一脚〈長三尺二寸、広二尺三寸、高一尺五寸五分、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00007.tif/full/full/0/default.jpg"/>
               料、漆二升五合、絹・布各一尺、綿十三両、掃墨五合、油一合、細布三尺、〈黏料、〉伊予砥・青砥各小半顆、炭二斗五升、単功十三人、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17100705 engishiki_v17_en.xml#item17100705" xml:id="item17100705"
                 ><anchor xml:id="app1710070501"/><anchor xml:id="app1710070501e"/>
@@ -1670,7 +1670,7 @@
             <p ana="項" corresp="engishiki_v17_ja.xml#item17100708 engishiki_v17_en.xml#item17100708" xml:id="item17100708"
                 ><anchor xml:id="app1710070801"/><anchor xml:id="app1710070801e"/>
               羮椀一口〈径七寸、〉料、漆一合二夕、朱沙一分、貲布五寸、絁・布各一寸、綿三分、掃墨二夕、油一夕、炭一升、長功一人小半、中功一人大 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00008.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00008.tif/full/full/0/default.jpg"/>
               半、短功二人、 </p>
             <app from="#app1710070801" to="#app1710070801e" type="標注">
               <lem wit="#壬本 #京博本"> 弘貞イ </lem>
@@ -1733,7 +1733,7 @@
               <rdg wit="#土本 #近本"/>
               <note> 弘　土本無し。壬本・京博本による。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00009.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00009.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17100714 engishiki_v17_en.xml#item17100714" xml:id="item17100714"
                 ><anchor xml:id="app1710071401"/><anchor xml:id="app1710071401e"/>
               盤一口〈径五寸、〉料、漆六夕、朱沙一分、貲布二寸、絁・布各一寸、綿一分、掃墨一夕、油一夕、炭一升、長功一人、中功一人小半、短功一人大半、 </p>
@@ -1759,7 +1759,7 @@
               櫛筥四合、〈各長一尺一寸五分、広一尺三寸、深一寸五分、〉刀子筥一合〈雁鼻、長一尺二寸、広一尺、深一寸二分、〉料、牛皮十張、〈各長八尺已下七尺已上、〉鹿皮十張、〈各長五尺已上、〉
               漆六斗六升四合、熟麻廿斤七両、〈張縄料、〉帛一丈五尺、 <placeName corresp="#石見国"> 石見 </placeName>
               庸綿廿二斤十両、掃墨二斗四合、粘料信濃調布四端二丈五尺、小麦二斗四合、伊予砥五顆、青砥四枚、 橡絁 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00010.tif/full/full/0/default.jpg"/>
               一疋三丈、〈革筥 <anchor xml:id="app1710090101"/> 工 <anchor xml:id="app1710090101e"/> 三人衣・袴料、〉苧四斤九両、〈 <anchor
                 xml:id="app1710090102"/> 縁 <anchor xml:id="app1710090102e"/> 料、〉絹六尺四寸、油三升 <anchor xml:id="app1710090103"/> 三合
                 <anchor xml:id="app1710090103e"/> 、鉄二廷、〈皮焼并皮刀料、〉調布八尺八寸、炭九斛二斗五升、和炭二斛二斗三 <anchor xml:id="app1710090104"/> 升
@@ -1828,7 +1828,7 @@
               、〈鏤肱金料、以二分充廿四枚、〉 水銀八十三両二分 <anchor xml:id="app1710110106"/> 二銖 <anchor xml:id="app1710110106e"/> 、〈廿五両塗肱金料、卅九両三分
                 <anchor xml:id="app1710110107"/> 二銖 <anchor xml:id="app1710110107e"/> 塗釘料、十八両三分合銀滅料、〉鉄四廷、〈三廷鋳釘湯鑵料、一廷鋳釘押形固料、〉
               漆一斗二升五合、〈以二合五夕、充押木廿四枚、〉絹一丈、布二端二丈、 <placeName corresp="#石見国"> 石見 </placeName> 綿四斤二両、麻大十斤、掃墨四升、油一升、酢九升三 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00011.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00011.tif/full/full/0/default.jpg"/>
               合、猪髪十把、 篦百五十株、〈塗花形釘金料、〉筆十五管、〈画肱金料、〉墨二廷、〈同料、〉洗革四枚、伊予砥七顆、青砥三枚、炭七十一斛七斗、和炭六十七斛九斗、
               単功二千八十四人、〈作骨工二百五十人、以一帖充五人、作肱金工千三百人、火作四百人、錯磨四百人、鏤打堺瑩五百人、作花形釘四百卅四人、鋳六十二人、錯三百十人、塗瑩六十 <anchor
                 xml:id="app1710110108"/> 二 <anchor xml:id="app1710110108e"/> 人、夫百人、〉 </p>
@@ -1911,7 +1911,7 @@
             <head ana="御帯"/>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17101401 engishiki_v17_en.xml#item17101401" xml:id="item17101401">
               馬瑙御腰帯一条〈六道、〉料、馬革一条、〈長七尺、広六寸、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00012.tif/full/full/0/default.jpg"/>
               縫料生糸一分、拭料調布五寸、入革脈料苧小一両、張革縄料麻小七両、粘料米一合、 作革料油一合、塩三合、糟三升、染料酢一合、漆 <anchor xml:id="app1710140101"/> 三 <anchor
                 xml:id="app1710140101e"/> 夕、炭五升、 <anchor xml:id="app1710140102"/> 銙具石 <anchor xml:id="app1710140102e"/>
               一顆、〈方四寸、〉切石料大坂沙一石、鉄三廷半、裏并 <anchor xml:id="app1710140103"/> 鈌 <anchor xml:id="app1710140103e"/> 料銀大六両、
@@ -1962,7 +1962,7 @@
             <head ana="外印"/>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17101701 engishiki_v17_en.xml#item17101701" xml:id="item17101701">
               外印一面料、熟銅大一斤、白𨭛大二両、﨟大 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00013.tif/full/full/0/default.jpg"/>
               二両、調布二尺、炭二斗、和炭二斗、長功七人、〈﨟工二人、鋳二人、磨三人、〉中功八人小半、短功九人大半、 </p>
           </div>
           <div ana="内匠" corresp="engishiki_v17_ja.xml#article171018 engishiki_v17_en.xml#article171018" n="17.18" type="条"
@@ -1995,7 +1995,7 @@
               御斗帳一具、〈高八尺一寸、方一丈二尺二寸、〉土居料六七寸桁二枝、柱料簀子 <anchor xml:id="app1710200101"/> 十 <anchor xml:id="app1710200101e"/>
               四枝、天井料檜榑八村、熟銅大八斤、滅金小六両二分、水銀小三両一分、 鉄二廷、膠小十二両、漆一斗四升、掃墨四升、洗刷料油四合、木賊四両、篦十株、洗革方一尺、酢二合、天井裏料白綾一疋五丈三尺、表料帛一疋五丈三尺、縫料糸三両、
               絞漆料帛三尺、 <placeName corresp="#石見国"> 石見 </placeName> 綿四 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00014.tif/full/full/0/default.jpg"/>
               斤、調布三尺、下銅湯料調布三尺、巾料布三尺、粘料糯米二升、伊予砥一顆半、青砥一枚、合漆料焼土一斗四升、炭二斛、和炭十一斛七斗五升、
               長功二百卌二人、〈木工七十一人半、銅卌二人半、鉄八人、画三人、漆百一人、張二人、夫十四人、〉中功二百八十二人小半、〈工二百六十六人、夫十六人小半、〉短功三百廿三人、〈工三百四人、夫十九人、〉 </p>
             <app from="#app1710200101" to="#app1710200101e">
@@ -2014,7 +2014,7 @@
               簀子敷并 <anchor xml:id="app1710210103"/> 棉梠 <anchor xml:id="app1710210103e"/>
               ・障子押等料檜榑二村、骨料榲榑二村、蓋椽料簀子木廿六枝、〈笠縫氏供、〉蓋下桟料川竹十株、蓋料菅一囲、〈 <placeName corresp="#山城国"> 山城国 </placeName> 進、〉
               熟銅大廿三斤、水銀小十五両、銀大一両二分、滅金小一斤十四両、釘料鉄三廷、膠小四両、漆一斗、掃墨三升、油四合、伊予砥一顆半、青砥一枚、障子料紫綾四丈、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00015.tif/full/full/0/default.jpg"/>
               下張料東絁三丈五尺六寸、縁料錦一丈三尺、縫料紫糸二両、生糸六両、絞漆料帛三尺、 <placeName corresp="#石見国"> 石見 </placeName> 綿三斤、調布一尺五寸、下銅湯料調布六尺、巾料調布六尺、
               浸菅并拭料商布一段、粘縁料薄紙十六張、糯米一升三合、小麦五合、焼土一斗、炭二斛七斗、和炭五十二斛五斗、 長功三百卌人、〈木工五十五人、銅百卌七人、鉄七人、漆六十人、画七人、張五人、縫笠廿人、夫卅九人、〉
               中功三百九十四人大半、〈工三百五十一人小半、夫 <anchor xml:id="app1710210104"/> 卌三人小半 <anchor xml:id="app1710210104e"/> 、〉短功 <anchor
@@ -2056,7 +2056,7 @@
               /> 、鳥居・高 <anchor xml:id="app1710220103"/> 欄 <anchor xml:id="app1710220103e"/> 料檜榑一村、熟銅大一斤十両、滅金小一両一分、
               水銀小二分三銖、鉄一廷、漆四升、掃墨一升五合、油二合、帛一尺二寸、 <placeName corresp="#石見国"> 石見 </placeName> 綿一斤八両、調布四尺二寸、伊予砥半顆、青砥一枚、焼土七升、炭六斗、
               和炭三斛二升、長功七十八人、〈木工廿四人、銅九人、鉄二人、画半人、漆卅六人、夫六 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00016.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00016.tif/full/full/0/default.jpg"/>
               人半、〉中功九十一人、〈工八十三人小半、夫七人大半、〉短功一百四人、〈工九十 <anchor xml:id="app1710220104"/> 五人半 <anchor xml:id="app1710220104e"/>
               、夫八人半、〉 </p>
             <app from="#app1710220101" to="#app1710220101e" type="標注">
@@ -2095,7 +2095,7 @@
                 石見 </placeName> 綿一斤八両、伊予砥一顆半、青砥一枚、白綾四丈、油絹二丈八尺、両面一丈一尺二寸、錦七尺五寸、 東絁二丈二尺四寸、練糸二両、調布三丈二寸、東席二枚、苧 <anchor
                 xml:id="app1710230109"/> 大 <anchor xml:id="app1710230109e"/> 五両、毛料草二囲半、糯米一升、小麦一升、炭九斗、和炭廿四斛六斗、熬炭五斗、焼土五升、
               長功二百九十二人半、〈木工一百十九人、銅五十六人半、鉄卅五人半、画三人、釭四人、張十二人、漆廿二人、夫卌人半、〉 中功三百卌一人、〈工二百九十四人、夫 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00017.tif/full/full/0/default.jpg"/>
               卌七人、〉短功三百八十九人大半、〈工三百卅六人、夫五十三人大半、〉 </p>
             <app from="#app1710230101" to="#app1710230101e">
               <lem wit="#土本 #近本 #壬本 #京博本"> 腰車 </lem>
@@ -2169,7 +2169,7 @@
                 xml:id="app1710240105e"/> 一斤四両、篦廿株、染料茜大三百斤、白米九斗、〈煮茜用度、〉酢一斛二斗、生絹四尺、〈篩茜料、〉 庸布四尺、〈篩皂料、〉灰卌五斛、〈斤別一斗五升、〉薪百五十荷、〈斤別
                 <anchor xml:id="app1710240106"/> 充 <anchor xml:id="app1710240106e"/> 半荷、〉染槽一隻、〈長一丈已下八尺以上、広三尺已下二尺以上、〉
               柴十五荷、杓二柄、水麻笥一口、〈受四斗已下、〉水 <anchor xml:id="app1710240107"/> 𤭖 <anchor xml:id="app1710240107e"/> 麻笥一口、〈受二斛、〉苧割雇女
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00018.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00018.tif/full/full/0/default.jpg"
               /> 単卅人食料、 <anchor xml:id="app1710240108"/> 米 <anchor xml:id="app1710240108e"/> 二斗四升、〈人別八合、〉酒一斗八升、〈人別六合、〉
               魚六升、〈人別二合、〉塩六合、〈人別二夕、〉海藻三連、〈人別一把、〉功新銭六十文、〈人別二文、〉工百三人、夫九十人、〈不論長短功、〉 </p>
             <app from="#app1710240101" to="#app1710240101e" type="標注">
@@ -2230,7 +2230,7 @@
               三 <anchor xml:id="app1710250101e"/> 両、同黄三分、青黛二分、胡粉五両、中烟子二枚、紫土二両、金薄卅枚、墨一廷、膠十四両、筆料鹿毛二両、
               切金薄革一条、〈方一尺、〉練糸一両、漆二合、掃墨一合、絞漆料帛一尺、 <placeName corresp="#石見国"> 石見 </placeName> 綿四両、調布一尺、洗刷料油五夕、金薄料綿二両、 <anchor
                 xml:id="app1710250102"/> 中子 <anchor xml:id="app1710250102e"/> 料調布二尺五寸、 瑩釘料調布三尺、下銅湯料調布一尺、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00019.tif/full/full/0/default.jpg"/>
               下張料商布二段一 <anchor xml:id="app1710250103"/> 丈 <anchor xml:id="app1710250103e"/>
               、粘縁料薄紙十四張、中張料紙六十五張、番中粘料紙五張、石灰二合、紫革一条、〈長一尺、広八寸、〉 糯米二升、小麦三升、炭五斛三斗、和炭一斛 <anchor xml:id="app1710250104"/> 三 <anchor
                 xml:id="app1710250104e"/> 斗、長功五十二人、〈木工三人、銅十五人、画廿人、漆二人、張十一人、夫一人、〉
@@ -2276,7 +2276,7 @@
               <note> 百　壬本・京博本等右上に「弘」を付す。あるいは27幄条の標目か。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00020.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00020.tif/full/full/0/default.jpg"/>
           <div ana="内匠" corresp="engishiki_v17_ja.xml#article171027 engishiki_v17_en.xml#article171027" n="17.27" type="条"
             xml:id="article171027">
             <head ana="幄"/>
@@ -2319,7 +2319,7 @@
               <note> 功一百卅四人、〈工九十六人、夫卅八人、〉　土本無し。近本・壬本等により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00021.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00021.tif/full/full/0/default.jpg"/>
           <div ana="内匠" corresp="engishiki_v17_ja.xml#article171031 engishiki_v17_en.xml#article171031" n="17.31" type="条"
             xml:id="article171031">
             <head ana="伊勢初斎院"/>
@@ -2337,7 +2337,7 @@
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103103 engishiki_v17_en.xml#item17103103" xml:id="item17103103">
               五尺屏風四帖料、榲榑十村、〈骨料、〉檜榑一村、〈押料、〉炭 <anchor xml:id="app1710310301"/> 三 <anchor xml:id="app1710310301e"/>
               斛、〈鋳釘并塗金料、〉和炭六斛、〈作肱金料、〉熟銅大三斤十二両、〈作肱金料、〉 半熟銅大十二斤、〈鋳釘料、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00022.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00022.tif/full/full/0/default.jpg"/>
               滅金十両三分、水銀五両二分、一窠白綾十二丈四尺、〈表料、〉縹絁十二丈四尺、〈裏料、〉紫綾五 <anchor xml:id="app1710310302"/> 丈 <anchor
                 xml:id="app1710310302e"/> 六尺、〈縁料、〉 緋絁二丈、〈番料、〉調布二丈、〈番中張料、〉商布九段一丈五尺、〈下張料、〉練糸一両、〈中張布縫料、〉紙二百五十張、〈中張料、〉薄紙五十六張、〈
                 <anchor xml:id="app1710310303"/> 縁 <anchor xml:id="app1710310303e"/> 料、〉 紫革一枚、〈長二尺五 <anchor
@@ -2352,7 +2352,7 @@
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103105 engishiki_v17_en.xml#item17103105" xml:id="item17103105">
               大翳筥二合料、波太板四枚、〈長六尺、厚一寸五分、広二尺、〉阿膠廿両、炭四斗、白𨭛薄十枚、〈方八寸、〉阿膠十両、信濃布四尺、炭四斗、
               漆四升、絹四尺、綿二屯、細布四尺、信濃布六尺、調布六尺、掃墨二升、焼土二升、油一合、伊予砥半顆、青砥一枚、炭二斗、 単功六十五人、〈木工廿人、漆廿人、白𨭛廿 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00023.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00023.tif/full/full/0/default.jpg"/>
               五人、〉 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103106 engishiki_v17_en.xml#item17103106" xml:id="item17103106">
               大笠柄二枝〈加志部、〉料、檜榑一村、白 <anchor xml:id="app1710310601"/> 𨭛 <anchor xml:id="app1710310601e"/>
@@ -2365,7 +2365,7 @@
               沓筥一合料、波太板半枚、阿膠五両、炭一斗、白𨭛薄二枚半、〈方八寸、〉阿膠二両二分、炭一斗、漆六合、絹八寸、綿四両、掃墨三合、 焼土二合、単功十人、〈木工二人半、漆三人、白𨭛四人半、〉 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103109 engishiki_v17_en.xml#item17103109" xml:id="item17103109">
               車榻一脚料、槻二枝、〈各長五尺、広四寸、厚二寸、〉檜榑一村、阿膠五両、鉄一廷、炭二斗、熟銅二斤十両、滅金四両、鑑銀一両二分、鉄半廷、 伊予砥一顆、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00024.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00024.tif/full/full/0/default.jpg"/>
               信濃布二丈、調布二丈、白𨭛薄三枚、〈方八寸、〉阿膠三両、信濃布五尺、漆一升五合、絹一尺五寸、綿七両、細布一尺五寸、 信濃布二尺、掃墨五合、焼土五合、単功卌人、〈木工八人、漆七人、銅十六人、白𨭛九人、〉 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103110 engishiki_v17_en.xml#item17103110" xml:id="item17103110">
               膳櫃四合、〈各長三尺二寸五分、広二尺二寸、深九寸、〉下居榻四脚、〈各長五尺六寸、高一尺七寸、〉並塗赤漆料、漆二升五合、〈櫃料一升六合、下居料九合、〉
@@ -2379,7 +2379,7 @@
               銀匕四枚料、銀廿四両、信濃布四尺、炭五斗、和炭一石、単功八人、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103114 engishiki_v17_en.xml#item17103114" xml:id="item17103114">
               手湯戸一合、〈腹周五尺、高一尺四寸、〉台一脚料、漆二升五合、絹一尺五寸、綿一屯、細布一尺五寸、貲布八尺、掃墨五合、焼土一升、油二合、炭五斗、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00025.tif/full/full/0/default.jpg"/>
               単功八人、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103115 engishiki_v17_en.xml#item17103115" xml:id="item17103115">
               手洗一口〈径一尺七寸、深六寸、〉料、漆一升、絹一尺、綿八両、細布三尺、調布四尺、掃墨五合、焼土六合、炭五斗、単功七人、 </p>
@@ -2397,7 +2397,7 @@
               張御殿蓋代料、調布十端、練糸一絇、苧小五斤、単功十四人、〈木工十二人、夫二人、〉 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103121 engishiki_v17_en.xml#item17103121" xml:id="item17103121">
               軽幄骨一具料、漆七升、絹五尺、綿二屯半、掃墨二升、焼土二升、青砥一枚、炭一斛、単功卌人、 </p>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00026.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00026.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103122 engishiki_v17_en.xml#item17103122" xml:id="item17103122">
               床一脚〈方六尺、〉料、漆四升、絹三尺、綿十 <anchor xml:id="app1710312201"/> 二 <anchor xml:id="app1710312201e"/>
               両、細布三尺、信濃布六尺、掃墨一升、焼土一升、伊予砥半顆、青砥一枚、炭五斗、単 <anchor xml:id="app1710312202"/> 功 <anchor xml:id="app1710312202e"/>
@@ -2568,7 +2568,7 @@
                 <anchor xml:id="app1710320202"/> 二 <anchor xml:id="app1710320202e"/> 寸、但一 <anchor xml:id="app1710320203"/> 枝
                 <anchor xml:id="app1710320203e"/>
               <anchor xml:id="app1710320204"/> 方一尺 <anchor xml:id="app1710320204e"/> 、〉朸料簀子二枚、障 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00027.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00027.tif/full/full/0/default.jpg"/>
               子骨料榲榑二村、 熟銅大卌六斤、滅金小一斤十二両、銀大一両、水銀小十四両、鉄三廷、炭二斛一斗、和炭五十斛五斗、漆九升、掃墨二升、焼土一斗、帛三尺、油三合、 浅紫纈帛三丈六尺、東絁三丈六尺、錦一丈三尺、紫 <anchor
                 xml:id="app1710320205"/> 糸 <anchor xml:id="app1710320205e"/> 二両、生糸六両、 <placeName corresp="#石見国"> 石見
               </placeName> 綿三斤、調布一丈三尺五寸、商布一段、苧小一斤、薄紙十五張、膠小四両、 伊予砥一顆、糯米一升三合、小麦五合、長功 <anchor xml:id="app1710320206"/> 三百廿九人
@@ -2578,7 +2578,7 @@
               腰輿一具、〈長一丈二尺、広二尺九寸、斗内長三尺、脚高五寸、〉障子二枚、〈一枚長五尺、広二尺、一枚長五尺、広二尺二寸、〉桁料簀子二枚、 壁代・梁料歩板一枚、高 <anchor xml:id="app1710320301"/>
               欄 <anchor xml:id="app1710320301e"/> ・鳥居等料檜榑半村、障子骨料榲榑一村、熟銅大十二斤、滅金小七両、水銀小三両二分、鉄一廷、漆四升、掃墨一升、帛一尺二寸、 <placeName
                 corresp="#石見国"> 石見 </placeName> 綿一斤八両、調布七尺二寸、油二合、浅紫纈帛二丈六尺、東絁二丈六 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00028.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00028.tif/full/full/0/default.jpg"/>
               尺、錦八尺、浅紫糸二分、練糸二分、薄紙八張、阿膠小二分、伊予砥、青砥、糯米六合、 小麦五合、炭一石、和炭十四斛 <anchor xml:id="app1710320302"/> 二 <anchor
                 xml:id="app1710320302e"/> 斗五升、長功 <anchor xml:id="app1710320303"/> 一百五十一人半 <anchor xml:id="app1710320303e"/>
               、〈木工廿五人、銅五十九人、鉄二人、漆卅六人、画三人、張三人、夫十三人半、〉 中功百八十人、〈工一百六十三人小半、夫十六人大半、〉短功二百五人大半、〈工一百八十六人大半、夫十九人、〉 </p>
@@ -2593,7 +2593,7 @@
               張御殿蓋代料、調布八端四尺、〈切廿条、 <anchor xml:id="app1710320601"/> 条 <anchor xml:id="app1710320601e"/> 別長一丈七尺、〉練糸一絇、苧小五斤、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103207 engishiki_v17_en.xml#item17103207" xml:id="item17103207">
               同宮 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00029.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00029.tif/full/full/0/default.jpg"/>
               自伊勢斎宮 <anchor xml:id="app1710320701"/> 入京 <anchor xml:id="app1710320701e"/> 儲料、御輿一具、〈並料物単功、同野宮、〉 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103208 engishiki_v17_en.xml#item17103208" xml:id="item17103208">
               四尺屏風四帖料榲榑八村、〈作骨料、〉檜榑半村、〈押料、〉熟銅大四斤、〈作肱金料、〉 半熟銅大十二斤、〈鋳花形釘料、〉炭五斛五斗、〈一斛五斗鋳花形釘料、一斛五斗塗 <anchor xml:id="app1710320801"
@@ -2610,7 +2610,7 @@
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103210 engishiki_v17_en.xml#item17103210" xml:id="item17103210">
               塗赤漆御膳櫃六合、〈各長二尺三寸、広二尺二寸、深八寸二分、〉下居机六脚、〈各長五尺七寸五分、広二尺三寸、高一尺七寸、〉朸十六枚、〈各長九尺、周六寸五分、〉 韓櫃一合、〈長二尺六寸、広一尺七寸、深一尺一寸、〉料、漆六升六合、
                 <placeName corresp="#石見国"> 石見 </placeName> 庸綿二斤、荏油一升八合、炭一斛、〈絞漆并塗料、〉 単功 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00030.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00030.tif/full/full/0/default.jpg"/>
               卌九人、〈御膳櫃并下机卅六人、朸十六枚五人、韓櫃三人、夫五人、〉 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103211 engishiki_v17_en.xml#item17103211" xml:id="item17103211"
                 ><anchor xml:id="app1710321101"/><anchor xml:id="app1710321101e"/>
@@ -2758,7 +2758,7 @@
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103303 engishiki_v17_en.xml#item17103303" xml:id="item17103303">
               櫛机一具〈長一尺五寸、広一尺三寸、足高九寸、〉料、波多板一枚、檜榑半村、阿膠十両、炭二斗一 <anchor xml:id="app1710330301"/> 升 <anchor
                 xml:id="app1710330301e"/> 、切釘廿隻、漆一升二合、掃墨三合、 焼土三合、綿六両、絹一尺、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00031.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00031.tif/full/full/0/default.jpg"/>
               手作布一尺、単 <anchor xml:id="app1710330302"/> 功 <anchor xml:id="app1710330302e"/> 九人、〈木工六人、漆三人、〉 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103304 engishiki_v17_en.xml#item17103304" xml:id="item17103304">
               膳櫃三合、〈加榻并朸、〉樽一荷、銀飯 <anchor xml:id="app1710330401"/> 鋎 <anchor xml:id="app1710330401e"/> 一合、銀水 <anchor
@@ -2777,7 +2777,7 @@
               白銅酒壺一合〈受一斗、〉料、白銅大廿斤、油五合、鉄三廷、炭卅斛、和炭一斛、信濃布一丈五尺、麻縄一了、伊予砥一顆、長功五十人、中功五十五人、短功六十人、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103310 engishiki_v17_en.xml#item17103310" xml:id="item17103310">
               白銅杓一柄〈加盤、〉料、白銅大十両、炭四斛、油 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00032.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00032.tif/full/full/0/default.jpg"/>
               一合、信濃布一丈、長功十人、中功十二人、短 <anchor xml:id="app1710331001"/> 功 <anchor xml:id="app1710331001e"/> 十四人、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103311 engishiki_v17_en.xml#item17103311" xml:id="item17103311">
               白銅風炉一具料、白銅大三斤、炭四斛、油一合五夕、信濃布七尺五寸、長功十人、中功十二人、短功十四人、 </p>
@@ -2787,7 +2787,7 @@
               朱漆台盤三面〈各三尺、加台、〉料、漆九升、朱砂卅両、掃墨三升、油五合、焼土五升、綿三屯、絹七尺、細布一丈二尺、信濃布一丈二尺、調布一丈五尺、伊予砥一顆、青砥二枚、阿膠十両、炭一斛、単功廿五人、 </p>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103314 engishiki_v17_en.xml#item17103314" xml:id="item17103314">
               酒海三合、〈各受二斗、〉二合料、漆四升、朱砂十六両、貲布一丈、絹・布各四尺、綿一斤、油四合、炭一斛、 一合料、漆二升、掃墨七合、焼土八合、貲布五尺、絹・布各一尺五寸、油一合、炭二斗五升、単功十三人、〈朱漆八人、墨漆五人、〉 </p>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00033.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00033.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103315 engishiki_v17_en.xml#item17103315" xml:id="item17103315"
                 ><anchor xml:id="app1710331501"/> 下食盤 <anchor xml:id="app1710331501e"/>
               十枚〈各方一尺七寸、〉料、漆五升、朱砂十二両、掃墨二升、焼土二升、油三合、貲布一丈、絹六尺、綿三屯、炭一斛、単功卅人、 </p>
@@ -2901,7 +2901,7 @@
             <p ana="項" corresp="engishiki_v17_ja.xml#item17103701 engishiki_v17_en.xml#item17103701" xml:id="item17103701"
                 ><anchor xml:id="app1710370101"/><anchor xml:id="app1710370101e"/> 凡 <orgName corresp="#木工寮"> 木工寮 </orgName>
               造大射・賭射・騎射等的、皆差 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00034.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00034.tif/full/full/0/default.jpg"/>
               向画師使塗画、 </p>
             <app from="#app1710370101" to="#app1710370101e" type="標注">
               <lem wit="#壬本"> 弘 </lem>
@@ -2997,7 +2997,7 @@
                 <cell> 延長五年十二月廿六日 </cell>
                 <cell> 外従五位下行左大史臣阿 <anchor xml:id="app1799990101"/> 刀 <anchor xml:id="app1799990101e"/> 宿禰忠行 </cell>
               </row>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00035.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00035.tif/full/full/0/default.jpg"/>
               <row>
                 <cell/>
                 <cell> 従五位上行勘解由次官兼大外記 <placeName corresp="#紀伊国"> 紀伊 </placeName> 権介臣伴宿禰久永 </cell>
@@ -3025,114 +3025,114 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-17/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-17">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4404" xml:id="page4404">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4405" xml:id="page4405">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4406" xml:id="page4406">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4407" xml:id="page4407">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4408" xml:id="page4408">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4409" xml:id="page4409">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4410" xml:id="page4410">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4411" xml:id="page4411">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4412" xml:id="page4412">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4413" xml:id="page4413">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4414" xml:id="page4414">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4415" xml:id="page4415">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4416" xml:id="page4416">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4417" xml:id="page4417">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4418" xml:id="page4418">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4419" xml:id="page4419">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4420" xml:id="page4420">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4421" xml:id="page4421">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4422" xml:id="page4422">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4423" xml:id="page4423">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4424" xml:id="page4424">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4425" xml:id="page4425">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4426" xml:id="page4426">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4427" xml:id="page4427">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4428" xml:id="page4428">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4429" xml:id="page4429">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4430" xml:id="page4430">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4431" xml:id="page4431">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4432" xml:id="page4432">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4433" xml:id="page4433">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4434" xml:id="page4434">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4435" xml:id="page4435">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4436" xml:id="page4436">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4437" xml:id="page4437">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4438" xml:id="page4438">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17/page4439" xml:id="page4439">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-17%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-17/00036.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v21.xml
+++ b/TEI編集用/engishiki_v21.xml
@@ -1383,7 +1383,7 @@
   <text>
     <body>
       <div ana="治部・雅楽・玄蕃・諸陵" n="21" type="巻" xml:id="volume21">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai21">
           <p xml:id="shudai2101"> 延喜式巻第廿一〈<orgName corresp="#治部省">治部</orgName>　<orgName corresp="#雅楽寮">雅楽</orgName>　<orgName
               corresp="#玄蕃寮">玄蕃</orgName>　<orgName corresp="#諸陵寮">諸陵</orgName>〉 </p>
@@ -1408,7 +1408,7 @@
               、不比不飛、〉同心鳥、永楽鳥、〈五色成文、丹喙、 <anchor xml:id="app2110010108"/> 赤 <anchor xml:id="app2110010108e"/>
               頭、頭上有冠、鳴云天下太平、〉富貴、〈鳥形獣頭、〉吉利、〈鳥形獣頭、〉神亀、〈黒神之精也、五色鮮明、知存亡明吉凶也、〉竜、〈被五色以遊、能幽能明、 <anchor xml:id="app2110010109"/> 能
                 <anchor xml:id="app2110010109e"/> 小能大、〉騶虞、〈義獣也、状如虎、白色黒文、尾長於身、不食生物也、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00004.tif/full/full/0/default.jpg"/>
               白沢、〈一名沢獣、 <anchor xml:id="app2110010110"/> 能 <anchor xml:id="app2110010110e"/> 言語知万物情、〉神馬、〈竜馬長 <anchor
                 xml:id="app2110010111"/> 頸 <anchor xml:id="app2110010111e"/> 、 <anchor xml:id="app2110010112"/> 額 <anchor
                 xml:id="app2110010112e"/> 上有翼、 <anchor xml:id="app2110010113"/> 踏 <anchor xml:id="app2110010113e"/>
@@ -1435,7 +1435,7 @@
                 xml:id="app2110010135e"/>
               如六十日犬子、食気飲露也、〉玉甕、〈不汲自満、〉神鼎、〈不汲自満也、一云不爨自沸、〉銀甕、〈不汲自満、〉瓶甕、〈不汲自満、〉丹甑、〈不炊自熟、〉醴泉、〈美泉也、其味美甘、状如醴酒、〉浪井、〈不鑿自成之井、而騰波浪者也、〉河水清、河水五色、
                 <anchor xml:id="app2110010136"/> 江 <anchor xml:id="app2110010136e"/> 水五色、海水不揚波、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00005.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00005.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent2"> 右、大瑞、 </seg>
             </p>
@@ -1722,7 +1722,7 @@
               而蒼色、江海不揚洪波、東海輸之、〉白睪、白雉、〈岱宗之精也、〉雉白首、翠鳥、〈羽有光耀也、〉黄鵠、小 <anchor xml:id="app2110030102"/> 鳥 <anchor
                 xml:id="app2110030102e"/> 生大鳥、朱雁、五色雁、白雀、赤狐、黄 <anchor xml:id="app2110030103"/> 羆 <anchor
                 xml:id="app2110030103e"/> 、青熊、玄貉、赤豹、白兎、〈月之精也、其寿千歳、〉九真奇獣、〈駒形、麟色、牛角、仁而愛人、〉流黄出谷、〈土精也、〉沢谷生白玉、瑯 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00006.tif/full/full/0/default.jpg"/>
               玕景、〈玉有光景者、〉碧石潤色、地出珠、陵出黒丹、威委、〈瑞木也、可以為琴瑟也、〉威綏、延 <anchor xml:id="app2110030104"/> 喜 <anchor
                 xml:id="app2110030104e"/> 、〈瑞草也、〉福幷、〈 <anchor xml:id="app2110030105"/> 瑞 <anchor xml:id="app2110030105e"/>
               草也、〉紫脱常生、〈瑞草也、〉賓連達、〈樹名也、一名賓連闊達、其状連累相承生房戸、象継嗣也、〉善茅、〈其頭若雄 <anchor xml:id="app2110030106"/> 雉 <anchor
@@ -1812,7 +1812,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21100501 engishiki_v21_ja.xml#item21100501" xml:id="item21100501">
               国忌 <lb/> 天智天皇〈十二月三日忌、崇福寺、〉 <lb/> 天宗高紹天皇〈十二月廿三日忌、東寺、〉 <lb/> 桓武天皇〈三月十七日忌、西寺、〉 <lb/> 皇太后〈三月十日忌、若有閏月、其月修、興福 <anchor
                 xml:id="app2110050101"/> 寺 <anchor xml:id="app2110050101e"/> 、〉 <lb/> 仁明天皇〈三月廿一日忌、東寺、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00007.tif/full/full/0/default.jpg"/>
               <lb/> 文徳天皇〈八月廿七日忌、西 <anchor xml:id="app2110050102"/> 寺 <anchor xml:id="app2110050102e"/> 、〉 <lb/> 贈皇太后〈六月晦日忌、
                 <anchor xml:id="app2110050103"/> 東寺 <anchor xml:id="app2110050103e"/> 、〉 <lb/> 光孝天皇〈八月廿六日忌、西 <anchor
                 xml:id="app2110050104"/> 寺 <anchor xml:id="app2110050104e"/> 、〉 <lb/>
@@ -1907,7 +1907,7 @@
             <head ana="外五位賻物"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21101001 engishiki_v21_ja.xml#item21101001" xml:id="item21101001">
               凡外五位賻物者、准内位減半給之、但五位 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00008.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00008.tif/full/full/0/default.jpg"/>
               郡司准職事例、以正税給之、 </p>
           </div>
           <div ana="治部" corresp="engishiki_v21-1_en.xml#article211011 engishiki_v21-1_ja.xml#article211011" n="21-1.11"
@@ -1974,7 +1974,7 @@
             <head ana="蕃客"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21101801 engishiki_v21_ja.xml#item21101801" xml:id="item21101801">
               凡蕃客入朝者、差領客使二人、〈掌在路雑事、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00009.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00009.tif/full/full/0/default.jpg"/>
                 随使一人、〈掌記録及公文事、〉掌客二人、〈掌在京雑事、有史生二人、〉共食二人、〈掌饗日各対使者飲宴、自余使見<orgName corresp="#太政官">太政官</orgName>式、〉 </p>
           </div>
           <div ana="治部" corresp="engishiki_v21-1_en.xml#article211019 engishiki_v21-1_ja.xml#article211019" n="21-1.19"
@@ -2039,7 +2039,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21200401 engishiki_v21_ja.xml#item21200401" xml:id="item21200401">
               凡正月最勝王経会、始終日官人率楽人等、左右相分供奉、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00010.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00010.tif/full/full/0/default.jpg"/>
           <div ana="雅楽" corresp="engishiki_v21-2_en.xml#article212005 engishiki_v21-2_ja.xml#article212005" n="21-2.5"
             type="条" xml:id="article212005">
             <head ana="東大寺仏会"/>
@@ -2129,7 +2129,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21201101 engishiki_v21_ja.xml#item21201101" xml:id="item21201101">
                 凡<orgName corresp="#太政官">太政官</orgName>列見・定考日、官人率楽人等祗候、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00011.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00011.tif/full/full/0/default.jpg"/>
           <div ana="雅楽" corresp="engishiki_v21-2_en.xml#article212012 engishiki_v21-2_ja.xml#article212012" n="21-2.12"
             type="条" xml:id="article212012">
             <head ana="蕃客宴饗"/>
@@ -2177,7 +2177,7 @@
                 <anchor xml:id="app2120170101"/> 二 <anchor xml:id="app2120170101e"/> 両、〉【竹/軍】篌一面、〈長六尺四寸五分、 <anchor
                 xml:id="app2120170102"/> 料 <anchor xml:id="app2120170102e"/> 糸二両、〉新羅琴一面、〈長五尺、 <anchor xml:id="app2120170103"
               /> 料 <anchor xml:id="app2120170103e"/> 糸四両、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00012.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent2"> 右、計所須糸、二年一度請受、 </seg>
             </p>
@@ -2242,7 +2242,7 @@
                 xml:id="app2130010101e"/>
                 四口、〈講読師従各二口、呪願以下従各一口、〉其講師者、経興福寺維摩会講師者便請之、読師者、内供奉十禅師及持律・持経・久修練行三色僧、逓以請用、但当用之時、具録其名簿幷次第、先申<orgName
                 corresp="#太政官">官</orgName>聴処分、不得輙恣、聴衆者、均択六宗学業有聞者次第請之、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00013.tif/full/full/0/default.jpg"/>
                 天台宗僧及四天王・梵釈・常住等寺、十禅師各一人亦預之、前斎四日、録名申<orgName corresp="#治部省">省</orgName>、 <orgName corresp="#治部省"><anchor
                   xml:id="app2130010102"/> 省 <anchor xml:id="app2130010102e"/></orgName> 申<orgName corresp="#太政官"
               >官</orgName>、〈事見儀式、〉 </p>
@@ -2285,7 +2285,7 @@
               <orgName corresp="#治部省">治部</orgName>
               <anchor xml:id="app2130040102e"/> 申<orgName corresp="#太政官"
               >官</orgName>、四月上旬請之、並起四月十五日尽七月十五日、分経講説、東大寺、法華・最勝・仁王般若経各一部、理趣般若・金剛般若経各一巻、興福・元興・大安・薬師・西大・法隆・新薬師・本元興・招提・西寺・四天王・崇福等十二寺、法華・最勝・仁王
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00014.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00014.tif/full/full/0/default.jpg"
               /> 般若経各一部、弘福寺、法華・最勝・維摩・仁王般若経各一部、東寺、法華・最勝・仁王般若・守護国界主経各一部、其施物、三宝糸卅絇、裹料調布九尺、木綿三分、講師絹五疋、綿十 <anchor
                 xml:id="app2130040103"/> 七 <anchor xml:id="app2130040103e"/>
               屯、調布廿五端、読師絹四疋、綿十屯、調布廿端、法用三口、別絹二疋、綿四屯、調布四端、定座沙弥調布四端、綿四屯、講読師沙弥綿二屯、調布二端、並用本寺物、但東・西二寺、猶用官家功徳分封物、 <anchor
@@ -2328,7 +2328,7 @@
               <note> 師　土本・近本・壬本・京博本・慶長本・梵本無し。九本により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00015.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00015.tif/full/full/0/default.jpg"/>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213007 engishiki_v21-3_ja.xml#article213007" n="21-3.7"
             type="条" xml:id="article213007">
             <head ana="大安寺大般若"/>
@@ -2350,7 +2350,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21300901 engishiki_v21_ja.xml#item21300901" xml:id="item21300901">
               凡崇福寺、毎年四月・十二月悔過各三日、〈四月十三日、十二月三日始行、〉其僧者、当寺供僧八口、三綱一口、威儀師若従儀師一口、並以次第請、其布施・供養用寺田地子物、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00016.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00016.tif/full/full/0/default.jpg"/>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213010 engishiki_v21-3_ja.xml#article213010" n="21-3.10"
             type="条" xml:id="article213010">
             <head ana="最勝会"/>
@@ -2401,7 +2401,7 @@
             <head ana="吉祥悔過"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21301401 engishiki_v21_ja.xml#item21301401" xml:id="item21301401">
                 凡<placeName corresp="#諸国">諸国</placeName>、起正月八日迄十四日、請部内諸寺僧於国庁、修吉祥悔過、〈国分寺僧専読最勝王経、不預此法、〉惣 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00017.tif/full/full/0/default.jpg"/>
                 計七僧法服幷布施料物、混合准価、平等布施、並用正税、其供養亦用正税、〈並見<orgName corresp="#主税寮">主税</orgName>式、〉但大宰観音寺於 <anchor
                 xml:id="app2130140101"/> 本 <anchor xml:id="app2130140101e"/> 寺修之、其布施・法服、准<placeName corresp="#諸国"
                 >諸国</placeName>数用府庫物、 </p>
@@ -2455,7 +2455,7 @@
                 corresp="#治部省">省</orgName>申<orgName corresp="#太政官">官</orgName>補 <anchor xml:id="app2130190101"/> 之 <anchor
                 xml:id="app2130190101e"/> 、 <anchor xml:id="app2130190102"/> 諸 <anchor xml:id="app2130190102e"/>
               寺僧無心願者、択百姓年六十已上者新度補之、但寺別令有壮年者五 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00018.tif/full/full/0/default.jpg"/>
               人、若見僧心願之内、壮年満此数、不 <anchor xml:id="app2130190103"/> 聴 <anchor xml:id="app2130190103e"/>
                 更新度、其尼者、講師与国司簡定、申<orgName corresp="#太政官">官</orgName>度之、 </p>
             <app from="#app2130190101" to="#app2130190101e">
@@ -2510,7 +2510,7 @@
                 凡<placeName corresp="#伊勢国">伊勢国</placeName>多度神宮寺僧十口度縁・戒牒准国分寺僧、勘納国庫、補替之日、副解文進<orgName corresp="#太政官"
                 >官</orgName>、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00019.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00019.tif/full/full/0/default.jpg"/>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213025 engishiki_v21-3_ja.xml#article213025" n="21-3.25"
             type="条" xml:id="article213025">
             <head ana="仁王会"/>
@@ -2558,7 +2558,7 @@
             <head ana="仁王会堂装束"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21302601 engishiki_v21_ja.xml#item21302601" xml:id="item21302601">
               堂装束 <lb/> 釈迦牟尼仏幷菩薩羅漢像一鋪、〈備仏台一 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00020.tif/full/full/0/default.jpg"/>
               具、蓋一条、榻幷褥一 <anchor xml:id="app2130260101"/> 具 <anchor xml:id="app2130260101e"/> 、 <anchor
                 xml:id="app2130260102"/> 小 <anchor xml:id="app2130260102e"/>
               幡四条、〉仁王般若経一部二巻、〈備経嚢一口、経台一基、経櫃一合、〉香花案一脚、〈備褥一条、香二両、火 <anchor xml:id="app2130260103"/> 鑪 <anchor
@@ -2572,7 +2572,7 @@
                 xml:id="app2130260109"/> 帊 <anchor xml:id="app2130260109e"/> 帯、〉又加鎮子鉄卌廷、敷地料改用調布廿端、自余雑物所司供設、 <lb/>
               <seg rendition="#indent2"> 右、諸堂所設如件、其仏像・経等雑調度、及高座・榻・案等類者、京畿 <anchor xml:id="app2130260110"/> 諸 <anchor
                   xml:id="app2130260110e"/> 国依件儲備、当有会事、便以供 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00021.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00021.tif/full/full/0/default.jpg"/>
                 用、 </seg>
             </p>
             <app from="#app2130260101" to="#app2130260101e">
@@ -2667,7 +2667,7 @@
             <head ana="仁王会読師"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21302801 engishiki_v21_ja.xml#item21302801" xml:id="item21302801">
               読師法服 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00022.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00022.tif/full/full/0/default.jpg"/>
               九条袈裟一条、蔭脊一条、帔一条、座具二枚、衫一領、汗衫一領、裳一腰、綿袴一腰、綿一屯、褌一腰、帯幷袴腰料 <anchor xml:id="app2130280101"/> 絁 <anchor
                 xml:id="app2130280101e"/> 六尺、湯巾料望陀布一条、襪一両、頭巾一条、手巾 <anchor xml:id="app2130280102"/> 一 <anchor
                 xml:id="app2130280102e"/> 条、唾巾曝布一条、〈已上丈尺並同上条、〉高鼻履一両、 <lb/>
@@ -2727,7 +2727,7 @@
               <note> 近本訂正書「諸」 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00023.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00023.tif/full/full/0/default.jpg"/>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213031 engishiki_v21-3_ja.xml#article213031" n="21-3.31"
             type="条" xml:id="article213031">
             <head ana="尊勝陀羅尼"/>
@@ -2776,7 +2776,7 @@
             <head ana="国忌座料"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21303601 engishiki_v21_ja.xml#item21303601" xml:id="item21303601">
               凡東西二寺国忌御斎会座料、両面端茵七枚、黄端茵四枚、黄端夾帖三枚、折 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00024.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00024.tif/full/full/0/default.jpg"/>
               薦帖廿枚、長帖廿枚、席十五枚、長席廿枚、簀十五枚、並以各寺官家功徳分物、造備供之、 </p>
           </div>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213037 engishiki_v21-3_ja.xml#article213037" n="21-3.37"
@@ -2832,7 +2832,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21303901 engishiki_v21_ja.xml#item21303901" xml:id="item21303901">
               凡僧綱勘知大寺雑事、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00025.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00025.tif/full/full/0/default.jpg"/>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213040 engishiki_v21-3_ja.xml#article213040" n="21-3.40"
             type="条" xml:id="article213040">
             <head ana="僧綱辞表"/>
@@ -2857,7 +2857,7 @@
             <head ana="従僧"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21304301 engishiki_v21_ja.xml#item21304301" xml:id="item21304301">
               凡僧正従僧五人、沙弥四人、童子八人、大少僧都各従僧四人、沙弥三人、童子六人、律師各従僧三人、沙弥二人、童子四人、威儀師各従僧一人、沙弥一人、童子二人、従儀師各沙弥一人、童子二人、東大寺別当従僧・沙弥・童子各二人、興福・元興・大安・薬師・西大・法隆・弘福・四天王・崇福等寺別当幷法華寺大鎮各従僧一人、沙弥一人、童子二人、三綱・少鎮沙弥一人、童子二人、並用本寺物供之、其童子各米
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00026.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00026.tif/full/full/0/default.jpg"
               /> 一升二合、塩五夕、 </p>
           </div>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213044 engishiki_v21-3_ja.xml#article213044" n="21-3.44"
@@ -2907,7 +2907,7 @@
             <head ana="夏講"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21304801 engishiki_v21_ja.xml#item21304801" xml:id="item21304801">
               凡諸寺僧夏講・供講者、依維摩・最勝両会立義之次第行之、然後擬補講師、又 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00027.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00027.tif/full/full/0/default.jpg"/>
               果三階之後、任読師之僧秩満帰本寺、即果遺二階任 <anchor xml:id="app2130480101"/> 講 <anchor xml:id="app2130480101e"/> 師者、 <anchor
                 xml:id="app2130480102"/> 歴 <anchor xml:id="app2130480102e"/> 一選之後擬補、 </p>
             <app from="#app2130480101" to="#app2130480101e">
@@ -2974,7 +2974,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21305501 engishiki_v21_ja.xml#item21305501" xml:id="item21305501">
                 凡大宰観音寺講読師者、預知管内<placeName corresp="#諸国">諸国</placeName>講読師所申之政、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00028.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00028.tif/full/full/0/default.jpg"/>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213056 engishiki_v21-3_ja.xml#article213056" n="21-3.56"
             type="条" xml:id="article213056">
             <head ana="講読師不与"/>
@@ -3034,7 +3034,7 @@
             <head ana="別当三綱闕"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21306001 engishiki_v21_ja.xml#item21306001" xml:id="item21306001">
               凡諸大寺別当・三綱有闕者、須五師大 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00029.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00029.tif/full/full/0/default.jpg"/>
                 衆簡定能治廉節之僧、別当・三綱共署申送、僧綱覆審具状牒送<orgName corresp="#玄蕃寮">寮</orgName>、 <orgName corresp="#玄蕃寮"><anchor
                   xml:id="app2130600101"/> 寮 <anchor xml:id="app2130600101e"/></orgName> 申<orgName corresp="#治部省"
                 >省</orgName>、<orgName corresp="#治部省">省</orgName>申<orgName corresp="#太政官"
@@ -3107,7 +3107,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21306601 engishiki_v21_ja.xml#item21306601" xml:id="item21306601">
                 凡諸定額寺別当、元来依<orgName corresp="#太政官">官</orgName>符任者、有闕則檀越氏人等、択定能治可称之僧、連署陳牒郡司、 <anchor xml:id="app2130660101"/>
               郡司 <anchor xml:id="app2130660101e"/> 牒送講読師、講読 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00030.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00030.tif/full/full/0/default.jpg"/>
                 師修状、牒送国司、国司申<orgName corresp="#太政官">官</orgName>補任、 </p>
             <app from="#app2130660101" to="#app2130660101e">
               <lem wit="#土本 #九本 #近本 #壬本 #京博本 #梵本"> 郡司 </lem>
@@ -3147,7 +3147,7 @@
               <lb/> 牒、 <anchor xml:id="app2130680103"/> 其 <anchor xml:id="app2130680103e"/> 月日因事解任、〈遷任亦同、〉仍与解由牒送、謹牒、 <lb/>
               <seg rendition="#indent4"> 年　月　日　都維那位名牒、 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00031.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00031.tif/full/full/0/default.jpg"/>
               別当位名 <lb/> 上座位名 <lb/>
               <anchor xml:id="app2130680104"/> 寺主位名 <anchor xml:id="app2130680104e"/>
               <lb/> 僧綱 <lb/> 僧正位名〈律師已上亦同、〉 </p>
@@ -3197,7 +3197,7 @@
               <anchor xml:id="app2130690110"/> 允 <anchor xml:id="app2130690110e"/> 位姓名 <lb/>
               <seg rendition="#indent18"> 属位姓名 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00032.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00032.tif/full/full/0/default.jpg"/>
               <orgName corresp="#治部省">治部省</orgName>
               <lb/>
               <seg rendition="#indent18"> 輔位姓名　　　　　　　　　　　　　 丞位姓名 </seg>
@@ -3299,7 +3299,7 @@
                 聴得度、其応度者、正月斎会畢日令度、畢<orgName corresp="#治部省">省</orgName>先責手実申<orgName corresp="#太政官">官</orgName>、与<orgName
                 corresp="#民部省">民部</orgName>共勘籍、即造度縁一通、<orgName corresp="#治部省">省</orgName>・<orgName corresp="#玄蕃寮"
                 >寮</orgName>・僧綱共署、向<orgName corresp="#太政官">太政官</orgName>請印、即授其身、其 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00033.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00033.tif/full/full/0/default.jpg"/>
                 別勅度者勘籍・度縁亦宜准此、但沙弥尼度縁者用<orgName corresp="#治部省">省</orgName>印、 </p>
             <app from="#app2130710101" to="#app2130710101e">
               <lem wit="#土本 #九本 #近本 #壬本 #京博本 #慶長本 #梵本"> 乃 </lem>
@@ -3356,7 +3356,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21307401 engishiki_v21_ja.xml#item21307401" xml:id="item21307401">
                 凡受戒時、<orgName corresp="#治部省">省</orgName>丞・録、<orgName corresp="#玄蕃寮"
                 >寮</orgName>允・属各一人、率史生各一人、与威従共向戒壇院、子細勘会<orgName corresp="#太政官">官</orgName>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00034.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00034.tif/full/full/0/default.jpg"/>
                 符・度縁、便収取受戒者戒牒、具注後紙以其本籍・姓名、即<orgName corresp="#治部省">省</orgName>・<orgName corresp="#玄蕃寮"
                 >寮</orgName>相共押署、捺以<orgName corresp="#治部省">省</orgName>印、五月以前下於僧綱、僧綱六月一日頒給、若有持白紙戒牒者、科違勅罪、 </p>
           </div>
@@ -3413,7 +3413,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21307701 engishiki_v21_ja.xml#item21307701" xml:id="item21307701">
               凡以七大寺僧為師主之輩、不聴預延暦寺授戒、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00035.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00035.tif/full/full/0/default.jpg"/>
           <div ana="玄蕃" corresp="engishiki_v21-3_en.xml#article213078 engishiki_v21-3_ja.xml#article213078" n="21-3.78"
             type="条" xml:id="article213078">
             <head ana="臨時度者"/>
@@ -3480,7 +3480,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21308401 engishiki_v21_ja.xml#item21308401" xml:id="item21308401">
               凡禅院寺経論、三年一度曝 <anchor xml:id="app2130840101"/> 涼 <anchor xml:id="app2130840101e"/> 、<orgName corresp="#省"
                 >省</orgName>・<orgName corresp="#寮">寮</orgName>・僧 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00036.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00036.tif/full/full/0/default.jpg"/>
               綱・三綱・檀越等相共検校、 </p>
             <app from="#app2130840101" to="#app2130840101e">
               <lem wit="#土本 #九本 #近本 #壬本 #京博本 #慶長本"> 涼 </lem>
@@ -3540,7 +3540,7 @@
             <head ana="誦経"/>
             <p ana="項" corresp="engishiki_v21_en.xml#item21309101 engishiki_v21_ja.xml#item21309101" xml:id="item21309101">
               凡王臣已下誦経布施物者、親王一品商布五百段已下、二品三百段已下、三品・四品各二百段已下、諸王・諸臣一位五百段已下、二位三百段已下、三位二百段已下、四位一百段已下、五位五十段已下、六位已下卅段已 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00037.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00037.tif/full/full/0/default.jpg"/>
               下、並三七若七七日一度施修、不得違差、非商布者亦准此数、若相労之人、必有可諷誦、只 <anchor xml:id="app2130910101"/> 許 <anchor xml:id="app2130910101e"/>
               二等已上親、其布施物、不得過本位数、 </p>
             <app from="#app2130910101" to="#app2130910101e">
@@ -3572,7 +3572,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21309301 engishiki_v21_ja.xml#item21309301" xml:id="item21309301">
               凡蕃客往還、若有水陸二路者、領客使与国 <anchor xml:id="app2130930101"/> 郡 <anchor xml:id="app2130930101e"/>
               相知、逐便預定一路、明注所須船・駄・人夫等数及客到時日、逓牒前所、応須供客之物、令預備擬、不得臨時改易及有 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00038.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00038.tif/full/full/0/default.jpg"/>
               停擁、如有事故、必須停滞及改張者、速 <anchor xml:id="app2130930102"/> 告 <anchor xml:id="app2130930102e"/> 前所勿致費損、 </p>
             <app from="#app2130930101" to="#app2130930101e">
               <lem wit="#土本 #九本 #近本 #壬本 #京博本 #慶長本 #梵本"> 郡 </lem>
@@ -3603,7 +3603,7 @@
               津国</placeName>遣迎船、〈王子来朝遣一国司、余使郡司、但大唐使者迎船有数、〉客 <anchor xml:id="app2130940109"/> 舶 <anchor
                 xml:id="app2130940109e"/> 将到難波津之日、国使着朝服、乗一装船、候於海上、客船来至、迎船趨進、客舶・迎 <anchor xml:id="app2130940110"/> 船 <anchor
                 xml:id="app2130940110e"/> 比及相近、客主停船、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00039.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00039.tif/full/full/0/default.jpg"/>
               国使立船上、客等朝服出立船上、時国使喚通事、通事称唯、国使宣云、日本〈尓〉明神〈登〉御宇天皇朝庭〈登、〉 <anchor xml:id="app2130940111"/> 其 <anchor
                 xml:id="app2130940111e"/> 蕃王〈能〉申上随〈尓〉参上来〈留〉客等参近〈奴登、〉<placeName corresp="#摂津国"
               >摂津国</placeName>守等聞着〈弖、〉水脈〈母〉教導賜〈幣登〉宣随〈尓、〉迎賜〈波久登〉宣、 <anchor xml:id="app2130940112"/> 客 <anchor
@@ -3760,7 +3760,7 @@
                   <cell><anchor xml:id="app2140020108"/> 室 <anchor xml:id="app2140020108e"/> 秋津島宮御宇孝安天皇、在<placeName
                       corresp="#大和国">大和国</placeName>葛上郡、兆域東西六町、南北六町、守戸五烟、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00040.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00040.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width170"> 片丘馬坂陵 </cell>
                   <cell> 〈 </cell>
@@ -4026,7 +4026,7 @@
                   <cell> 近飛鳥八釣宮御宇顕宗天皇、在 <placeName corresp="#大和国"><anchor xml:id="app2140020307"/> 大和 <anchor
                         xml:id="app2140020307e"/> 国</placeName>葛下郡、兆域東西二町、南北三町、陵戸一烟、守戸三烟、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00041.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00041.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width170"> 埴生坂本陵 </cell>
                   <cell> 〈 </cell>
@@ -4290,7 +4290,7 @@
                       xml:id="app2140040103"/> 合 <anchor xml:id="app2140040103e"/> 葬檜前大内陵、 <anchor xml:id="app2140040104"/> 陵
                       <anchor xml:id="app2140040104e"/> 戸更不重充、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00042.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00042.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width170"> 真弓丘陵 </cell>
                   <cell> 〈 </cell>
@@ -4527,7 +4527,7 @@
                     南五町、西 <anchor xml:id="app2140070102"/> 三 <anchor xml:id="app2140070102e"/> 町 <anchor
                       xml:id="app2140070101e"/> 、北六町、加丑寅角二岑一谷、守戸五烟、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00043.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00043.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width170"> 高 <anchor xml:id="app2140070103"/> 畠 <anchor xml:id="app2140070103e"/> 陵 </cell>
                   <cell> 〈 </cell>
@@ -4695,7 +4695,7 @@
                       xml:id="app2140110107"/> 分 <anchor xml:id="app2140110107e"/> 、〉 </cell>
                 </row>
               </table>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00044.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00044.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"> 右三、近陵、 </seg>
             </p>
@@ -4888,7 +4888,7 @@
                   <cell><anchor xml:id="app2140130201"/> 茅渟 <anchor xml:id="app2140130201e"/> 皇子、在<placeName corresp="#大和国"
                       >大和国</placeName>葛下郡、兆域東西五町、南北五町、無守戸、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00045.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00045.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width170"> 檜隈墓 </cell>
                   <cell> 〈 </cell>
@@ -5064,7 +5064,7 @@
                       xml:id="app2140160102"/> 麻呂 <anchor xml:id="app2140160102e"/> 、在<placeName corresp="#大和国"
                       >大和国</placeName>宇智郡、兆域東西十五町、南北十五町、守戸一烟、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00046.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00046.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width170"> 相楽墓 </cell>
                   <cell> 〈 </cell>
@@ -5207,7 +5207,7 @@
                   <cell> 贈太政 <anchor xml:id="app2140170104"/> 大臣 <anchor xml:id="app2140170104e"/> 正一位藤原朝臣高藤、在<placeName
                       corresp="#山城国">山城国</placeName>宇治郡小野郷、〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00047.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00047.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width170"> 後小野墓 </cell>
                   <cell> 〈 </cell>
@@ -5274,7 +5274,7 @@
                 xml:id="app2140190105e"/> 、<orgName corresp="#大蔵省">大蔵省</orgName>進申積幣物訖、〈事見<orgName corresp="#大蔵省"
                 >大蔵</orgName>式、〉即参議已上 <anchor xml:id="app2140190106"/> 令 <anchor xml:id="app2140190106e"/> 召使喚<orgName
                 corresp="#治部省">治部 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00048.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00048.tif/full/full/0/default.jpg"/>
                 省</orgName>如常、丞進就版位、即宣曰、率使者等参来、両<orgName corresp="#治部省 #大蔵省">省</orgName>輔、<orgName corresp="#諸陵寮"
                 >寮</orgName>属已上、進共就座、省掌率使者等、列於庭中、〈西面北上、〉先是<orgName corresp="#大蔵省">大蔵</orgName>丞・録各一人、就 <anchor
                 xml:id="app2140190107"/> 頒 <anchor xml:id="app2140190107e"/> 幣之座、<orgName corresp="#治部省"
@@ -5352,7 +5352,7 @@
             <p ana="項" corresp="engishiki_v21_en.xml#item21402201 engishiki_v21_ja.xml#item21402201" xml:id="item21402201">
                 凡陵墓側近有原野者、<orgName corresp="#諸陵寮">寮</orgName>仰守戸、并移所在国司、共相知焼除、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00049.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00049.tif/full/full/0/default.jpg"/>
           <div ana="諸陵" corresp="engishiki_v21-4_en.xml#article214023 engishiki_v21-4_ja.xml#article214023" n="21-4.23"
             type="条" xml:id="article214023">
             <head ana="官人巡検"/>
@@ -5369,156 +5369,156 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-21/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-21">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4546" xml:id="page4546">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4547" xml:id="page4547">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4548" xml:id="page4548">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4549" xml:id="page4549">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4550" xml:id="page4550">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4551" xml:id="page4551">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4552" xml:id="page4552">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4553" xml:id="page4553">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4554" xml:id="page4554">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4555" xml:id="page4555">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4556" xml:id="page4556">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4557" xml:id="page4557">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4558" xml:id="page4558">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4559" xml:id="page4559">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4560" xml:id="page4560">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4561" xml:id="page4561">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4562" xml:id="page4562">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4563" xml:id="page4563">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4564" xml:id="page4564">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4565" xml:id="page4565">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4566" xml:id="page4566">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4567" xml:id="page4567">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4568" xml:id="page4568">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4569" xml:id="page4569">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4570" xml:id="page4570">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4571" xml:id="page4571">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4572" xml:id="page4572">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4573" xml:id="page4573">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4574" xml:id="page4574">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4575" xml:id="page4575">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4576" xml:id="page4576">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4577" xml:id="page4577">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4578" xml:id="page4578">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4579" xml:id="page4579">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4580" xml:id="page4580">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4581" xml:id="page4581">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00036.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4582" xml:id="page4582">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00037.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00037.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4583" xml:id="page4583">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00038.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00038.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4584" xml:id="page4584">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00039.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00039.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4585" xml:id="page4585">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00040.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00040.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4586" xml:id="page4586">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00041.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00041.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4587" xml:id="page4587">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00042.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00042.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4588" xml:id="page4588">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00043.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00043.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4589" xml:id="page4589">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00044.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00044.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4590" xml:id="page4590">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00045.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00045.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4591" xml:id="page4591">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00046.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00046.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4592" xml:id="page4592">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00047.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00047.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4593" xml:id="page4593">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00048.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00048.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4594" xml:id="page4594">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00049.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00049.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21/page4595" xml:id="page4595">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-21%2F00050.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-21/00050.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v22.xml
+++ b/TEI編集用/engishiki_v22.xml
@@ -1354,7 +1354,7 @@
   <text>
     <body>
       <div ana="民部上" n="22" type="巻" xml:id="volume22">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai22">
           <p xml:id="shudai2201"> 延喜式巻第廿二 </p>
         </div>
@@ -1389,7 +1389,7 @@
                   <cell> 〈 </cell>
                   <cell> 管　大鳥　和泉　日根〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00003.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00003.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width80"><placeName corresp="#摂津国"> 摂津国 </placeName> 上 </cell>
                   <cell> 〈 </cell>
@@ -1467,7 +1467,7 @@
                   <cell rendition="#width80"><placeName corresp="#武蔵国"> 武蔵国 </placeName> 大 </cell>
                   <cell> 〈 </cell>
                   <cell> 管　久良　都筑　多麻　橘樹　荏原　豊島　足立　新座　入間　高麗　比企　横見 <pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00004.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00004.tif/full/full/0/default.jpg"
                     /> 埼玉　大里　男衾　幡羅　榛沢　那珂　児玉　賀美　秩父〉 </cell>
                 </row>
                 <row>
@@ -1588,7 +1588,7 @@
                   <cell> 〈 </cell>
                   <cell> 管　白河　磐瀬　会津　耶麻　安 <anchor xml:id="app2210030105"/> 積 <anchor xml:id="app2210030105e"/> 安達　信夫　刈田
                       <anchor xml:id="app2210030106"/> 柴 <anchor xml:id="app2210030106e"/> 田　名取　菊多　磐城 <pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00005.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00005.tif/full/full/0/default.jpg"
                     /> 標葉　行方　宇多　伊具　曰理　宮城　黒川　賀美　色麻　玉造　志太　栗原　磐井　江刺　胆沢　長岡　新田　小田　遠田　登米　桃生　気仙 <anchor xml:id="app2210030107"/> 牡
                       <anchor xml:id="app2210030107e"/> 鹿〉 </cell>
                 </row>
@@ -1746,7 +1746,7 @@
                   <cell> 〈 </cell>
                   <cell> 管 <anchor xml:id="app2210050101"/> 加 <anchor xml:id="app2210050101e"/> 佐　与謝　丹波　竹野　熊野〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00006.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00006.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width80"><placeName corresp="#但馬国"> 但馬国 </placeName> 上 </cell>
                   <cell> 〈 </cell>
@@ -1847,7 +1847,7 @@
                 </row>
               </table>
               <seg rendition="#indent2"> 右為中国、 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00007.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00007.tif/full/full/0/default.jpg"/>
               <table rendition="#indent1">
                 <row>
                   <cell rendition="#width80"><placeName corresp="#安芸国"> 安芸国 </placeName> 上 </cell>
@@ -1973,7 +1973,7 @@
                   <cell> 管 <anchor xml:id="app2210080102"/> 御原 <anchor xml:id="app2210080102e"/> 生葉　竹野　山本　御井 <anchor
                       xml:id="app2210080108"/> 三瀦 <anchor xml:id="app2210080108e"/> 上妻　下妻　山門　三毛〉 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00008.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00008.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width80"><placeName corresp="#豊前国"> 豊前国 </placeName> 上 </cell>
                   <cell> 〈 </cell>
@@ -2094,7 +2094,7 @@
             <p ana="項" corresp="engishiki_v22_en.xml#item22101101 engishiki_v22_ja.xml#item22101101" xml:id="item22101101"> 凡
                 <placeName corresp="#諸国"> 諸国 </placeName> 部内郡・里等名、並用二字、必取嘉名、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00009.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00009.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221012 engishiki_v22_ja.xml#article221012" n="22.12" type="条"
             xml:id="article221012">
             <head ana="貢限"/>
@@ -2162,7 +2162,7 @@
             <head ana="畿内調物"/>
             <p ana="項" corresp="engishiki_v22_en.xml#item22101901 engishiki_v22_ja.xml#item22101901" xml:id="item22101901"> 凡
                 <placeName corresp="#畿内"> 畿内 </placeName> 調物者、専当国司部領納京庫、其郡司 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00010.tif/full/full/0/default.jpg"/>
               者不可入京、 </p>
           </div>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221020 engishiki_v22_ja.xml#article221020" n="22.20" type="条"
@@ -2236,7 +2236,7 @@
               <note> 尹　土本「君」。九本・壬本・京博本・慶長本・梵本、近本訂正書により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00011.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00011.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221027 engishiki_v22_ja.xml#article221027" n="22.27" type="条"
             xml:id="article221027">
             <head ana="志摩国使"/>
@@ -2324,7 +2324,7 @@
             <p ana="項" corresp="engishiki_v22_en.xml#item22103801 engishiki_v22_ja.xml#item22103801" xml:id="item22103801"> 凡
                 <placeName corresp="#美濃国"> 美濃国 </placeName> 坂本・土岐・大井三駅、 <placeName corresp="#信濃国"> 信濃国 </placeName> 阿 <anchor
                 xml:id="app2210380101"/> 知 <anchor xml:id="app2210380101e"/> 駅 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00012.tif/full/full/0/default.jpg"/>
               子、課役並免、其 <placeName corresp="#畿内"> 畿内 </placeName> 駅子亦免課徭、 </p>
             <app from="#app2210380101" to="#app2210380101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #慶長本 #梵本"> 知 </lem>
@@ -2408,7 +2408,7 @@
             <head ana="飛騨匠丁"/>
             <p ana="項" corresp="engishiki_v22_en.xml#item22104701 engishiki_v22_ja.xml#item22104701" xml:id="item22104701"> 凡
                 <placeName corresp="#飛騨国"> 飛騨国 </placeName> 、毎年貢匠丁一百人、其返抄准 <placeName corresp="#諸国"> 諸国 </placeName> 調 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00013.tif/full/full/0/default.jpg"/>
               庸例、 </p>
           </div>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221048 engishiki_v22_ja.xml#article221048" n="22.48" type="条"
@@ -2461,7 +2461,7 @@
               <note> 得　京博本「門」とし、「得イ」と朱傍書。梵本「門」とし、「将」と訂正書。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00014.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00014.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221054 engishiki_v22_ja.xml#article221054" n="22.54" type="条"
             xml:id="article221054">
             <head ana="中宮封"/>
@@ -2524,7 +2524,7 @@
             <p ana="項" corresp="engishiki_v22_en.xml#item22106101 engishiki_v22_ja.xml#item22106101" xml:id="item22106101">
               凡点仕丁者、毎五十戸二人、〈采女採薪守舎不入此数、〉不点廝丁、其大替前年四月 <orgName corresp="#民部省"> 省 </orgName> 預勘録応点人数、申<orgName corresp="#太政官"
                 >官</orgName>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00015.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00015.tif/full/full/0/default.jpg"/>
               下 <anchor xml:id="app2210610101"/> 符 <anchor xml:id="app2210610101e"/> 、国司計帳之日点定、十二月下旬以前附 <anchor
                 xml:id="app2210610102"/> 綱 <anchor xml:id="app2210610102e"/> 送 <orgName corresp="#民部省"> 省 </orgName>
               、月内相替、令得給粮、其名簿先附大帳使進 <orgName corresp="#民部省"> 省 </orgName> 、但 <placeName corresp="#志摩国"> 志摩 </placeName> ・
@@ -2583,7 +2583,7 @@
               凡衛士・仕丁養物者、随郷所出、正丁七人半、惣所輸徭分稲一百五十束、准当土沽価交易軽物及舂米、所得之数専入正身、〈女丁亦同、〉其検納之事委各本司・本家、皆附貢調使申送 <orgName corresp="#民部省"> 省
               </orgName> 、〈但衛士各送 <anchor xml:id="app2210660101"/> 本 <anchor xml:id="app2210660101e"/>
               府、〉其逃人資物各給替人、若無替人者入官、諸家封 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00016.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00016.tif/full/full/0/default.jpg"/>
               戸仕丁者、不論逃否皆給主家、 </p>
             <app from="#app2210660101" to="#app2210660101e">
               <lem wit="#九本 #壬本 #京博本 #慶長本 #梵本 #近本抹消"> 本 </lem>
@@ -2674,7 +2674,7 @@
             <head ana="堀江寺"/>
             <p ana="項" corresp="engishiki_v22_en.xml#item22107501 engishiki_v22_ja.xml#item22107501" xml:id="item22107501"> 凡
                 <placeName corresp="#摂津国"> 摂津国 </placeName> 堀江寺、充土人二人・浪人十人令護仏経、並 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00017.tif/full/full/0/default.jpg"/>
               免課徭、有死闕者随即差替、 </p>
           </div>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221076 engishiki_v22_ja.xml#article221076" n="22.76" type="条"
@@ -2772,7 +2772,7 @@
               </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00018.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00018.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221083 engishiki_v22_ja.xml#article221083" n="22.83" type="条"
             xml:id="article221083">
             <head ana="籍書紙"/>
@@ -2844,7 +2844,7 @@
             <p ana="項" corresp="engishiki_v22_en.xml#item22109001 engishiki_v22_ja.xml#item22109001" xml:id="item22109001">
               凡入色之輩得度幷補左右近衛・兵衛・門部等、勿更勘籍、補自余色者亦同、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00019.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00019.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221091 engishiki_v22_ja.xml#article221091" n="22.91" type="条"
             xml:id="article221091">
             <head ana="得度"/>
@@ -2934,7 +2934,7 @@
               <note> 々　九本無し。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00020.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00020.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221099 engishiki_v22_ja.xml#article221099" n="22.99" type="条"
             xml:id="article221099">
             <head ana="位田二分"/>
@@ -3023,7 +3023,7 @@
             <p ana="項" corresp="engishiki_v22_en.xml#item22111001 engishiki_v22_ja.xml#item22111001" xml:id="item22111001">
               凡遥授国司、不給公廨田幷事力、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00021.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00021.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221111 engishiki_v22_ja.xml#article221111" n="22.111" type="条"
             xml:id="article221111">
             <head ana="巫田"/>
@@ -3098,7 +3098,7 @@
               <note> 国　訳注本は考異に従い削る。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00022.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00022.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221121 engishiki_v22_ja.xml#article221121" n="22.121" type="条"
             xml:id="article221121">
             <head ana="佐渡国"/>
@@ -3217,7 +3217,7 @@
               <note> 色　土本・近本・壬本・京博本・慶長本・梵本「邑」。九本により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00023.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00023.tif/full/full/0/default.jpg"/>
           <div ana="民部上" corresp="engishiki_v22_en.xml#article221130 engishiki_v22_ja.xml#article221130" n="22.130" type="条"
             xml:id="article221130">
             <head ana="陸田班授"/>
@@ -3301,7 +3301,7 @@
             <head ana="供御料"/>
             <p ana="項" corresp="engishiki_v22_en.xml#item22114101 engishiki_v22_ja.xml#item22114101" xml:id="item22114101">
               凡供御及中宮・東宮季料稲・粟・糯等、並用 <orgName corresp="#宮内省"> 省 </orgName>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00024.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00024.tif/full/full/0/default.jpg"/>
                 営田所穫、待<orgName corresp="#太政官">官</orgName>符至、仰 <placeName corresp="#畿内"> 畿内 </placeName> 令進、但粟 <placeName
                 corresp="#山城国"> 山城国 </placeName> 進之、 </p>
           </div>
@@ -3373,84 +3373,84 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-22/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-22">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4596" xml:id="page4596">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4597" xml:id="page4597">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4598" xml:id="page4598">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4599" xml:id="page4599">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4600" xml:id="page4600">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4601" xml:id="page4601">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4602" xml:id="page4602">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4603" xml:id="page4603">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4604" xml:id="page4604">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4605" xml:id="page4605">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4606" xml:id="page4606">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4607" xml:id="page4607">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4608" xml:id="page4608">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4609" xml:id="page4609">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4610" xml:id="page4610">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4611" xml:id="page4611">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4612" xml:id="page4612">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4613" xml:id="page4613">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4614" xml:id="page4614">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4615" xml:id="page4615">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4616" xml:id="page4616">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4617" xml:id="page4617">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4618" xml:id="page4618">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4619" xml:id="page4619">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4620" xml:id="page4620">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22/page4621" xml:id="page4621">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-22%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-22/00026.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v23.xml
+++ b/TEI編集用/engishiki_v23.xml
@@ -1379,7 +1379,7 @@
     <body>
       <div ana="民部下" n="23" type="巻" xml:id="volume23">
         <pb
-          facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00002.tif/full/full/0/default.jpg"/>
+          facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai23">
           <p xml:id="shudai2301"> 延喜式巻第廿三 </p>
         </div>
@@ -1437,7 +1437,7 @@
               xml:id="item23100301"> 凡東大寺大仏一季供養料稲百十束、法隆・弘福<anchor xml:id="app2310030101"/>寺<anchor
                 xml:id="app2310030101e"/>
               <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00003.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00003.tif/full/full/0/default.jpg"
               /> 二寺仏供養各卌一束四把、並以<placeName corresp="#大和国">大和国</placeName><anchor
                 xml:id="app2310030102"/>官<anchor xml:id="app2310030102e"/>田稲、季別送入寺家、 </p>
             <app from="#app2310030101" to="#app2310030101e">
@@ -1512,7 +1512,7 @@
                 xml:id="app2310080101"/>箭<anchor xml:id="app2310080101e"/>柳篦四百<anchor
                 xml:id="app2310080102"/>廿<anchor xml:id="app2310080102e"/>、<orgName corresp="#隼人司"
                 >隼人司</orgName>油絹料二百<pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00004.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00004.tif/full/full/0/default.jpg"
                 />隻、並仰<placeName corresp="#大和国">大和国</placeName>、毎年交易令送、〈箭篦以時採乾、<anchor
                 xml:id="app2310080103"/>簡<anchor xml:id="app2310080103e"
                 />取強好、〉価并運賃並用正税、其熬笥・灑籠等料竹、令<placeName corresp="#山城国">山城</placeName>・<placeName
@@ -1607,7 +1607,7 @@
             </p>
           </div>
           <pb
-            facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00005.tif/full/full/0/default.jpg"/>
+            facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00005.tif/full/full/0/default.jpg"/>
           <div ana="民部下"
             corresp="engishiki_v23_en.xml#article231016 engishiki_v23_ja.xml#article231016"
             n="23.16" type="条" xml:id="article231016">
@@ -1722,7 +1722,7 @@
             <p ana="項" corresp="engishiki_v23_en.xml#item23102201 engishiki_v23_ja.xml#item23102201"
               xml:id="item23102201"> 凡<placeName corresp="#諸国">諸国</placeName>地子帳、造三通、一通送<orgName
                 corresp="#主税寮">主税寮</orgName>、一通<orgName corresp="#主計寮">主計寮</orgName>、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00006.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00006.tif/full/full/0/default.jpg"
               /> 一通<orgName corresp="#太政官"
                 >官</orgName>厨、具録田上中下及損益、附正税帳使申送、若不填去年勘出物者、拘留税帳返抄、神税帳造二通、一通送<orgName corresp="#神祇官"
                 >神祇官</orgName>、一通送<orgName corresp="#民部省">省</orgName>、 </p>
@@ -1837,7 +1837,7 @@
               xml:id="item23102801"> 凡官物運京応差綱領者、米三百石已上差国司史生已上勝任者充、不満此数、差郡司及子弟<anchor
                 xml:id="app2310280101"/>並<anchor xml:id="app2310280101e"
               />百姓殷富家口重大者、自余雑物亦准此数、若有損失官物者、科処如法、其物以五分論、三分徴 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00007.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00007.tif/full/full/0/default.jpg"
               /> 綱、二分徴脚、但漂失物者、惣計所乗之人、半分已上死者、経告随近官司、<anchor xml:id="app2310280102"/>請<anchor
                 xml:id="app2310280102e"/>証験・証署、分明乃従免除、送<anchor xml:id="app2310280103"/>承<anchor
                 xml:id="app2310280103e"/>告之司、検実与験、若不加勘知、輙与公験者、並与同罪、 </p>
@@ -1943,7 +1943,7 @@
                 xml:id="app2310360101"/>若<anchor xml:id="app2310360101e"/>経年致損、便充公用、廻旧収新<anchor
                 xml:id="app2310360102"/>供<anchor xml:id="app2310360102e"/>事、其修理<orgName
                 corresp="#大宰府">府</orgName>中館舎料稲四 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00008.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00008.tif/full/full/0/default.jpg"
               /> 万束、毎年出挙六国、取其息利充用、若利満一万束者停挙、 </p>
             <app from="#app2310360101" to="#app2310360101e">
               <lem wit="#土本 #近本 #慶長本 #京博本傍書">若</lem>
@@ -2019,7 +2019,7 @@
                 >肥後</placeName>・<placeName corresp="#日向国">日向</placeName>三国、並以牧馬充之、 </p>
           </div>
           <pb
-            facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00009.tif/full/full/0/default.jpg"/>
+            facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00009.tif/full/full/0/default.jpg"/>
           <div ana="民部下"
             corresp="engishiki_v23_en.xml#article231042 engishiki_v23_ja.xml#article231042"
             n="23.42" type="条" xml:id="article231042">
@@ -2111,7 +2111,7 @@
                 corresp="#阿波国">阿波</placeName>十張、並以駅・伝・牧等死馬皮熟而送之、若不足者、買備満数、其直充正税、 </p>
           </div>
           <pb
-            facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00010.tif/full/full/0/default.jpg"/>
+            facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00010.tif/full/full/0/default.jpg"/>
           <div ana="民部下"
             corresp="engishiki_v23_en.xml#article231046 engishiki_v23_ja.xml#article231046"
             n="23.46" type="条" xml:id="article231046">
@@ -2231,7 +2231,7 @@
                 >讃岐</placeName>六月卅日以前、<placeName corresp="#備中国">備中</placeName>・<placeName
                 corresp="#備後国">備後</placeName>・<placeName corresp="#安芸国">安芸</placeName>・<placeName
                 corresp="#伊予国">伊予</placeName>・<placeName corresp="#土佐国">土左</placeName>八月卅日以前、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00011.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00011.tif/full/full/0/default.jpg"
               /> 並送納訖、若有未進者、准未進数奪専当郡司職田直、若不足者、亦没国司公廨、 </p>
           </div>
           <div ana="民部下"
@@ -2288,7 +2288,7 @@
                 >出雲国</placeName>〈四千五百斛、〉　<placeName corresp="#石見国"
                 >石見国</placeName>〈二千五百斛、〉　<placeName corresp="#長門国"
                 >長門国</placeName>〈二千卌七石、〉　<placeName corresp="#紀伊国">紀 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00012.tif/full/full/0/default.jpg"
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00012.tif/full/full/0/default.jpg"
                 /> 伊国</placeName>〈三千<anchor xml:id="app2310520105"/>百<anchor xml:id="app2310520105e"
                 />石、〉　<placeName corresp="#淡路国">淡路国</placeName>〈一千六百斛、〉 <lb/><seg
                 rendition="#indent">右廿五<anchor xml:id="app2310520106"/>国<anchor
@@ -2550,7 +2550,7 @@
                 ana="#年料別貢雑物" type="actual" commodity="#柏" corresp="#播磨国"><anchor
                   xml:id="app2310530124"/>柏<measure quantity="100">一百<unit unitRef="#俵"
                   >俵</unit></measure><anchor xml:id="app2310530124e"/></measure>、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00013.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00013.tif/full/full/0/default.jpg"
               /> 　<placeName corresp="#美作国">美作国</placeName>〈<measure ana="#年料別貢雑物" type="actual"
                 commodity="#筆" corresp="#美作国">筆<measure quantity="60">六十<unit unitRef="#管"
                   >管</unit></measure></measure>、<measure ana="#年料別貢雑物" type="actual" commodity="#紙麻"
@@ -2922,7 +2922,7 @@
               xml:id="item23105701"> 凡<orgName corresp="#大宰府">大宰府</orgName>年料造進<anchor
                 xml:id="app2310570101"/>朱<anchor xml:id="app2310570101e"/>漆酒海六合、〈三合径二<anchor
                 xml:id="app2310570102"/>尺<anchor xml:id="app2310570102e"/>、三合径一尺六寸、〉下食 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00014.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00014.tif/full/full/0/default.jpg"
               />
               盤六十枚、〈径一尺七寸、〉中盤八十八枚、〈径一尺、〉飯椀一百口、〈径七寸、〉羮椀二百口、〈百口径六寸五分、百口径六寸、〉盤四百五十枚、〈卅枚径七寸、二百廿枚径六寸、二百枚径五寸五分、〉盞二百五十口、〈百五十口径五寸、百口径四寸五分、〉黒漆提壺十四口、 </p>
             <app from="#app2310570101" to="#app2310570101e">
@@ -2972,7 +2972,7 @@
                 >若狭国</placeName>八壺〈並小一升、〉　<placeName corresp="#越前国"
                 >越前国</placeName>十五壺〈六口各大一升、九口各小一升、〉　<placeName corresp="#加賀国"
               >加賀国</placeName>十五壺〈六口各大一升、九口各小一升、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00015.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent"><anchor xml:id="app2310580106"/>右八箇国<anchor
                   xml:id="app2310580106e"/>為第三番、〈卯酉年〉</seg>
               <lb/><placeName corresp="#能登国">能登国</placeName>九壺〈三口各大一升、六口各小一升、〉　<placeName
@@ -3082,7 +3082,7 @@
               xml:id="item23105901"> 凡<placeName corresp="#諸国"
                 >諸国</placeName>貢蘇、各依番次、当年十一月以前進了、但<placeName corresp="#出雲国"
               >出雲国</placeName>十二月為限、輪転随次、終而復始、其取 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00016.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00016.tif/full/full/0/default.jpg"
               /> 得乳者、肥牛日大八合、痩牛減半、作蘇之法、乳大一斗煎、得蘇大一升、但飼秣者頭別日四把、 </p>
           </div>
           <div ana="民部下"
@@ -3233,7 +3233,7 @@
                 corresp="#大和国">瓠<measure quantity="325">三百廿五<unit unitRef="#柄"
                 >柄</unit></measure></measure>、<measure ana="#交易雑器" type="actual" commodity="#置簀"
                 corresp="#大和国">置簀 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00017.tif/full/full/0/default.jpg"
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00017.tif/full/full/0/default.jpg"
                   /><measure quantity="4"> 四<unit unitRef="#枚"
                 >枚</unit></measure></measure>、<placeName corresp="#河内国">河内国</placeName>、<measure
                 ana="#交易雑器" type="actual" commodity="#酒槽" corresp="#河内国">酒槽<measure quantity="34"
@@ -3483,7 +3483,7 @@
                 >斤</unit></measure></measure>、<measure ana="交易雑物" commodity="#於胡菜" corresp="#尾張国"
                 type="actual">於胡菜<measure quantity="30">三十<unit unitRef="#斤"
                 >斤</unit></measure></measure>、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00018.tif/full/full/0/default.jpg"/>
               <placeName corresp="#参河国">参河国</placeName>〈<measure ana="交易雑物" commodity="#白絹"
                 corresp="#参河国" type="actual">白絹<measure quantity="120">百二十<unit unitRef="#疋"
                     >疋</unit></measure></measure>、<measure ana="交易雑物" commodity="#鹿革" corresp="#参河国"
@@ -3821,7 +3821,7 @@
                   /><measure quantity="10">十<unit unitRef="#張">張</unit></measure></measure>、<measure
                 ana="交易雑物" commodity="#櫑子" corresp="#下野国" type="actual">櫑子<measure quantity="4"
                     >四<unit unitRef="#合_unit">合</unit></measure></measure>、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00019.tif/full/full/0/default.jpg"/>
               <placeName corresp="#陸奥国">陸奥国</placeName>〈<measure ana="交易雑物" commodity="#葦鹿皮"
                 corresp="#陸奥国" type="actual">葦鹿皮</measure>・<measure ana="交易雑物" commodity="#独犴皮"
                 corresp="#陸奥国" type="actual">独犴皮数随得</measure>、<measure ana="交易雑物" commodity="#砂金"
@@ -4137,7 +4137,7 @@
                 /></unit></measure></measure>、<measure ana="交易雑物" commodity="#醤大豆" corresp="#備後国"
                 type="actual">醤大豆<measure quantity="60">六十<unit unitRef="#石"
                 >石</unit></measure></measure>、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00020.tif/full/full/0/default.jpg"/>
               <measure ana="交易雑物" commodity="#醤大豆" corresp="#備後国" type="conditional">隔三年進醤大豆<measure
                   quantity="10">十<unit unitRef="#石">石</unit></measure></measure>、〉<placeName
                 corresp="#安芸国">安芸国</placeName>〈<measure ana="交易雑物" commodity="#白絹" corresp="#安芸国"
@@ -4735,7 +4735,7 @@
             <head ana="当年充進"/>
             <p ana="項" corresp="engishiki_v23_en.xml#item23106501 engishiki_v23_ja.xml#item23106501"
               xml:id="item23106501"> 凡<placeName corresp="#諸国">諸国</placeName>年料雑交易物者、当年充進、不得 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00021.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00021.tif/full/full/0/default.jpg"
               /> 踰年、若有未進、<anchor xml:id="app2310650101"/>拘<anchor xml:id="app2310650101e"/>調庸返抄、 </p>
             <app from="#app2310650101" to="#app2310650101e">
               <lem wit="#近本訂正書 #京博本朱訂正書">拘</lem>
@@ -4818,143 +4818,143 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-23/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-23">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4622"
       xml:id="page4622">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00001.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00001.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4623"
       xml:id="page4623">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00002.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00002.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4624"
       xml:id="page4624">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00003.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00003.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4625"
       xml:id="page4625">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00004.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00004.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4626"
       xml:id="page4626">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00005.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00005.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4627"
       xml:id="page4627">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00006.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00006.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4628"
       xml:id="page4628">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00007.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00007.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4629"
       xml:id="page4629">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00008.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00008.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4630"
       xml:id="page4630">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00009.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00009.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4631"
       xml:id="page4631">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00010.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00010.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4632"
       xml:id="page4632">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00011.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00011.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4633"
       xml:id="page4633">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00012.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00012.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4634"
       xml:id="page4634">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00013.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00013.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4635"
       xml:id="page4635">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00014.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00014.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4636"
       xml:id="page4636">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00015.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00015.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4637"
       xml:id="page4637">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00016.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00016.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4638"
       xml:id="page4638">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00017.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00017.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4639"
       xml:id="page4639">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00018.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00018.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4640"
       xml:id="page4640">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00019.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00019.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4641"
       xml:id="page4641">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00020.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00020.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4642"
       xml:id="page4642">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00021.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00021.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4643"
       xml:id="page4643">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00022.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00022.tif/full/full/0/default.jpg"
       />
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23/page4644"
       xml:id="page4644">
       <graphic
-        url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-23%2F00023.tif/full/full/0/default.jpg"
+        url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-23/00023.tif/full/full/0/default.jpg"
       />
     </surface>
   </facsimile>

--- a/TEI編集用/engishiki_v24.xml
+++ b/TEI編集用/engishiki_v24.xml
@@ -1371,7 +1371,7 @@
   <text>
     <body>
       <div ana="主計上" n="24" type="巻" xml:id="volume24">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai24">
           <p xml:id="shudai2401"> 延喜式巻第廿四 </p>
         </div>
@@ -1503,7 +1503,7 @@
                         <measure quantity="7"> 七 <unit unitRef="#寸"> 寸 </unit>
                         </measure>
                       </measureGrp> 、 <measureGrp type="height"><measure quantity="1"><pb
-                            facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00003.tif/full/full/0/default.jpg"
+                            facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00003.tif/full/full/0/default.jpg"
                           /> 深一 <unit unitRef="#尺"> 尺 </unit>
                         </measure><measure quantity="1"> 一 <unit unitRef="#寸"> 寸 </unit>
                         </measure></measureGrp>
@@ -1932,7 +1932,7 @@
                     </measureGrp> 、〉 </note>
                 </measure>
               </measure>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00004.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00004.tif/full/full/0/default.jpg"/>
               <measure ana="#調" commodity="#贄土師竃子" type="standard"> 竃子 <measure quantity="10"> 十 <unit unitRef="#口"
                     xml:id="measure2410010309"> 口 </unit> 、 <note target="#measure2410010309"> 〈 <measure ana="Volume"
                       quantity="1" sameAs="#measure2410010309"> 受一 <unit unitRef="#斗"> 斗 </unit>
@@ -2139,7 +2139,7 @@
                 </measure> 、 <note target="#measure2410020201 #measure2410020202"> 〈両面已下各 <measureGrp><measure quantity="6"
                       type="depth"> 長六 <unit unitRef="#丈"> 丈 </unit>
                     </measure> 、 <measureGrp type="width"><measure quantity="1"><pb
-                          facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00005.tif/full/full/0/default.jpg"
+                          facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00005.tif/full/full/0/default.jpg"
                         /> 広一 <unit unitRef="#尺"> 尺 </unit>
                       </measure><measure quantity="9"> 九 <unit unitRef="#寸"> 寸 </unit>
                       </measure></measureGrp> 、 </measureGrp> 〉 </note>
@@ -2474,7 +2474,7 @@
                     > 口 </unit>
                 </measure>
               </measure> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00006.tif/full/full/0/default.jpg"/>
               <measure ana="#調" commodity="#鉢" type="standard"> 鉢 <measure quantity="30"> 卅 <unit unitRef="#口"> 口 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#須恵器酢瓶下盤" type="standard"> 酢瓶下盤 <measure quantity="40"><unit
@@ -2739,7 +2739,7 @@
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#雑魚腊" type="standard"><anchor xml:id="app2410020707"/> 雑 <anchor
                   xml:id="app2410020707e"/>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00007.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00007.tif/full/full/0/default.jpg"
                 /> 魚腊 <measure ana="Weight" quantity="26"> 廿六 <unit unitRef="#斤"> 斤 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#鮹腊" type="standard"> 鮹腊 <measure ana="Weight" quantity="4"> 四 <unit
@@ -3036,7 +3036,7 @@
                             </unit>
                           </measure>
                           <measure quantity="1"> 一 <unit unitRef="#分_Length"> 分 </unit> 、 <pb
-                              facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00008.tif/full/full/0/default.jpg"
+                              facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00008.tif/full/full/0/default.jpg"
                             />
                           </measure>
                         </measureGrp>
@@ -3276,7 +3276,7 @@
                   </measure><measure quantity="10"> 十 <unit unitRef="#両"> 両 </unit>
                   </measure></measureGrp>
               </measure> 、 <measure ana="#中男作物" commodity="#鮭氷頭合作" type="standard"> 鮭氷頭 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00009.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00009.tif/full/full/0/default.jpg"/>
                 合作 <measureGrp ana="Weight"><measure quantity="1"> 一 <unit unitRef="#斤"> 斤 </unit>
                   </measure><measure quantity="10"> 十 <unit unitRef="#両"> 両 </unit>
                   </measure></measureGrp>
@@ -3574,7 +3574,7 @@
               <measure ana="#調" commodity="#上糸" type="standard"><measure ana="Weight" quantity="1500"> 一千五百 <unit
                     unitRef="#絇"> 絇 </unit>
                 </measure></measure> 、並七月卅日以前納訖、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00010.tif/full/full/0/default.jpg"/>
               <lb/>
               <placeName corresp="#伊勢国"> 伊勢 </placeName>
               <placeName corresp="#参河国"> 参河 </placeName>
@@ -3671,7 +3671,7 @@
               <placeName corresp="#播磨国"> 播磨 </placeName>
               <placeName corresp="#美作国"> 美作 </placeName>
               <placeName corresp="#備前国"> 備前 </placeName>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00011.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00011.tif/full/full/0/default.jpg"/>
               <placeName corresp="#備中国"> 備中 </placeName>
               <placeName corresp="#備後国"> 備後 </placeName>
               <placeName corresp="#安芸国"> 安芸 </placeName>
@@ -3781,7 +3781,7 @@
               <note> 輸　土本・近本・壬本・京博本「転」。享保版本に従い改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00012.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00012.tif/full/full/0/default.jpg"/>
           <div ana="主計上" corresp="engishiki_v24_en.xml#article241010 engishiki_v24_ja.xml#article241010" n="24.10" type="条"
             xml:id="article241010">
             <head ana="河内国"/>
@@ -3899,7 +3899,7 @@
                 </measure>
               </measure> 、自余輸 <measure ana="#調" commodity="#銭" corresp="#摂津国" type="actual"> 銭 </measure> 、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00013.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00013.tif/full/full/0/default.jpg"/>
           <div ana="主計上" corresp="engishiki_v24_en.xml#article241012 engishiki_v24_ja.xml#article241012" n="24.12" type="条"
             xml:id="article241012">
             <head ana="和泉国"/>
@@ -4060,7 +4060,7 @@
                 </measure> 、 <note target="#measure2410130104"> 〈夏調、〉 </note>
               </measure> 自余輸 <measure ana="#調" commodity="#糸" corresp="#伊賀国" type="actual"> 糸 </measure> ・ <measure ana="#調"
                 commodity="#調布" corresp="#伊賀国" type="actual"> 布 </measure> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00014.tif/full/full/0/default.jpg"/>
               <lb/> 庸、 <measure ana="#庸" commodity="#白木韓櫃" corresp="#伊賀国" type="actual"> 白木韓櫃 <measure quantity="9"> 九 <unit
                     unitRef="#合_set"> 合 </unit>
                 </measure>
@@ -4214,7 +4214,7 @@
               </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00015.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00015.tif/full/full/0/default.jpg"/>
           <div ana="主計上" corresp="engishiki_v24_en.xml#article241016 engishiki_v24_ja.xml#article241016" n="24.16" type="条"
             xml:id="article241016">
             <head ana="尾張国"/>
@@ -4378,7 +4378,7 @@
             <head ana="遠江国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24101801 engishiki_v24_ja.xml#item24101801" xml:id="item24101801"
                 ><placeName corresp="#遠江国"> 遠江国 </placeName> 〈行程、上十五日、下八日、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00016.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00016.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#一窠綾" corresp="#遠江国" type="actual"> 一窠綾 <measure quantity="13"> 十三 <unit
                     unitRef="#疋"> 疋 </unit>
                 </measure>
@@ -4528,7 +4528,7 @@
             <head ana="伊豆国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24102001 engishiki_v24_ja.xml#item24102001" xml:id="item24102001"
                 ><placeName corresp="#伊豆国"> 伊豆国 </placeName> 〈行程、上廿二日、下十一日、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00017.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#一窠綾" corresp="#伊豆国" type="actual"> 一窠綾 <measure quantity="3"> 三 <unit
                     unitRef="#疋"> 疋 </unit>
                 </measure>
@@ -4627,7 +4627,7 @@
             <head ana="武蔵国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24102301 engishiki_v24_ja.xml#item24102301" xml:id="item24102301"
                 ><placeName corresp="#武蔵国"> 武蔵国 </placeName> 〈行程、上廿九日、下十五日、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00018.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#緋帛" corresp="#武蔵国" type="actual"> 緋帛 <measure quantity="60"> 六十 <unit
                     unitRef="#疋"> 疋 </unit>
                 </measure>
@@ -4770,7 +4770,7 @@
                 <measure quantity="148"> 一百卌八 <unit unitRef="#端_調布"> 端 </unit>
                 </measure>
               </measure> 、自余輸 <measure ana="#調" commodity="#望陀布" corresp="#上総国" type="actual"> 望陀 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00019.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00019.tif/full/full/0/default.jpg"/>
                 布 </measure> ・ <measure ana="#調" commodity="#細布" corresp="#上総国" type="actual"> 細布 </measure> ・ <measure
                 ana="#調" commodity="#調布" corresp="#上総国" type="actual"> 調布 </measure> ・ <measure ana="#調" commodity="#鰒"
                 corresp="#上総国" type="actual"> 鰒 </measure> 、 <lb/> 庸、輸 <measure ana="#庸" commodity="#庸布" corresp="#上総国"
@@ -4883,7 +4883,7 @@
             <head ana="近江国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24102801 engishiki_v24_ja.xml#item24102801" xml:id="item24102801"
                 ><placeName corresp="#東山道"> 東山道 </placeName><lb/><placeName corresp="#近江国"> 近江国 </placeName> 〈行程、上一日、下半日、〉
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00020.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00020.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#二色綾" corresp="#近江国" type="actual"> 二色綾 <measure quantity="30"> 卅 <unit
                     unitRef="#疋"> 疋 </unit>
                 </measure>
@@ -5073,7 +5073,7 @@
                     unitRef="#口"> 口 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#足下坏" corresp="#美濃国" type="actual"> 足下 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00021.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00021.tif/full/full/0/default.jpg"/>
                 坏 <measure quantity="50"> 五十 <unit unitRef="#口"> 口 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#油坏" corresp="#美濃国" type="actual"> 油坏 <measure quantity="36"> 卅六
@@ -5200,7 +5200,7 @@
             <head ana="上野国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24103201 engishiki_v24_ja.xml#item24103201" xml:id="item24103201"
                 ><placeName corresp="#上野国"> 上野国 </placeName> 〈行程、上廿九日、下十四日、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00022.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00022.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#緋帛" corresp="#上野国" type="actual"> 緋帛 <measure quantity="50"> 五十 <unit
                     unitRef="#疋"> 疋 </unit>
                 </measure>
@@ -5322,7 +5322,7 @@
             <head ana="若狭国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24103601 engishiki_v24_ja.xml#item24103601" xml:id="item24103601"
                 ><placeName corresp="#北陸道"> 北陸道 </placeName><pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00023.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00023.tif/full/full/0/default.jpg"
                 /><lb/><placeName corresp="#若狭国"> 若狭国 </placeName> 〈行程、上三日、下二 <anchor xml:id="app2410360101"/> 日 <anchor
                 xml:id="app2410360101e"/> 、〉 <lb/> 調、 <measure ana="#調" commodity="#絹" corresp="#若狭国" type="actual"> 絹
               </measure> 、 <measure ana="#調" commodity="#薄鰒" corresp="#若狭国" type="actual"> 薄鰒 </measure> 、 <measure ana="#調"
@@ -5449,7 +5449,7 @@
                     unitRef="#疋"> 疋 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#白絹" corresp="#加賀国" type="actual"> 白 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00024.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00024.tif/full/full/0/default.jpg"/>
                 絹 <measure quantity="10"> 十 <unit unitRef="#疋"> 疋 </unit>
                 </measure>
               </measure> 、自余輸 <measure ana="#調" commodity="#絹" corresp="#加賀国" type="actual"> 絹 </measure> 、 <lb/> 庸、 <measure
@@ -5550,7 +5550,7 @@
             <head ana="越後国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24104101 engishiki_v24_ja.xml#item24104101" xml:id="item24104101"
                 ><placeName corresp="#越後国"> 越後国 </placeName> 〈行程、上卅四日、下十七日、〉海路卅六日、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00025.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#白絹" corresp="#越後国" type="actual"> 白絹 <measure quantity="10"> 十 <unit
                     unitRef="#疋"> 疋 </unit>
                 </measure>
@@ -5668,7 +5668,7 @@
               </measure> 、 <measure ana="#調" commodity="#緋帛" corresp="#丹後国" type="actual"> 緋帛 <measure quantity="20"><unit
                     unitRef="#疋"/></measure>
               </measure> ・ <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00026.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00026.tif/full/full/0/default.jpg"/>
               <measure ana="#調" commodity="#縹帛" corresp="#丹後国" type="actual"> 縹帛各 <measure quantity="20"> 廿 <unit
                     unitRef="#疋"> 疋 </unit>
                 </measure>
@@ -5797,7 +5797,7 @@
                   xml:id="app2410460103e"/>
               </measure> 、 <measure ana="#中男作物" commodity="#漆" corresp="#因幡国" type="actual"> 漆 </measure> 、 <measure
                 ana="#中男作物" commodity="#海石榴油" corresp="#因幡国" type="actual"> 海石榴 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00027.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00027.tif/full/full/0/default.jpg"/>
                 油 </measure> 、 <measure ana="#中男作物" commodity="#平栗子" corresp="#因幡国" type="actual"> 平栗子 </measure> 、 <measure
                 ana="#中男作物" commodity="#火乾年魚" corresp="#因幡国" type="actual"> 火乾年魚 </measure> 、 <measure ana="#中男作物"
                 commodity="#鮐皮" corresp="#因幡国" type="actual"> 鮐皮 </measure> 、 <measure ana="#中男作物" commodity="#雑腊"
@@ -5930,7 +5930,7 @@
             <p ana="項" corresp="engishiki_v24_en.xml#item24104901 engishiki_v24_ja.xml#item24104901" xml:id="item24104901"
                 ><placeName corresp="#石見国"> 石見国 </placeName> 〈行程、上廿九日、下十五日、〉 <lb/> 調、庸、並輸 <measure ana="#調 #庸" commodity="#綿"
                 corresp="#石見国" type="actual"> 綿 </measure> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00028.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00028.tif/full/full/0/default.jpg"/>
               <lb/> 中男作物、 <measure ana="#中男作物" commodity="#紙" corresp="#石見国" type="actual"> 紙 </measure> 、 <measure
                 ana="#中男作物" commodity="#紅花" corresp="#石見国" type="actual"> 紅花 </measure> 、 <measure ana="#中男作物"
                 commodity="#薄鰒" corresp="#石見国" type="actual"> 薄鰒 </measure> 、 <measure ana="#中男作物" commodity="#雑腊"
@@ -6063,7 +6063,7 @@
                     unitRef="#口"> 口 </unit>
                 </measure>
               </measure> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00029.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00029.tif/full/full/0/default.jpg"/>
               <measure ana="#調" commodity="#鉢" corresp="#播磨国" type="actual"> 鉢 <measure quantity="32"> 卅二 <unit unitRef="#口">
                     口 </unit>
                 </measure>
@@ -6246,7 +6246,7 @@
               <rdg wit="#壬本 #京博本 #玄梁本"> 【糸+象】 </rdg>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00030.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00030.tif/full/full/0/default.jpg"/>
           <div ana="主計上" corresp="engishiki_v24_en.xml#article241053 engishiki_v24_ja.xml#article241053" n="24.53" type="条"
             xml:id="article241053">
             <head ana="備前国"/>
@@ -6393,7 +6393,7 @@
                     <unit unitRef="#絇"> 絇 </unit>
                 </measure>
               </measure> 、自 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00031.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00031.tif/full/full/0/default.jpg"/>
               余輸 <measure ana="#調" commodity="#絹" corresp="#備中国" type="actual"> 絹 </measure> ・ <measure ana="#調"
                 commodity="#鍬" corresp="#備中国" type="actual"> 鍬 </measure> ・ <measure ana="#調" commodity="#鉄" corresp="#備中国"
                 type="actual"> 鉄 </measure> ・ <measure ana="#調" commodity="#塩" corresp="#備中国" type="actual"> 塩 </measure> 、
@@ -6497,7 +6497,7 @@
               </measure> 自余輸 <measure ana="#調" commodity="#絹" corresp="#安芸国" type="actual"> 絹 </measure> ・ <measure ana="#調"
                 commodity="#糸" corresp="#安芸国" type="actual"> 糸 </measure> ・ <measure ana="#調" commodity="#塩" corresp="#安芸国"
                 type="actual"> 塩 </measure> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00032.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00032.tif/full/full/0/default.jpg"/>
               <lb/> 庸、 <measure ana="#庸" commodity="#白木韓櫃" corresp="#安芸国" type="actual"> 白木韓櫃 <measure quantity="10"> 十 <unit
                     unitRef="#合_set"> 合 </unit>
                 </measure>
@@ -6604,7 +6604,7 @@
                   quantity="20"><unit unitRef="#絇"/></measure>
               </measure> ・ <measure ana="#調" commodity="#緑糸" corresp="#紀伊国" type="actual"> 緑糸各 <measure ana="Weight"
                   quantity="20"> 廿 <pb
-                    facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00033.tif/full/full/0/default.jpg"/>
+                    facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00033.tif/full/full/0/default.jpg"/>
                   <unit unitRef="#絇"> 絇 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#橡糸" corresp="#紀伊国" type="actual"> 橡糸 <measure ana="Weight"
@@ -6719,7 +6719,7 @@
                   </measure><measure quantity="8"> 八 <unit unitRef="#両"> 両 </unit>
                   </measure></measureGrp>
               </measure> 、自余輸 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00034.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00034.tif/full/full/0/default.jpg"/>
               <measure ana="#調" commodity="#絹" corresp="#阿波国" type="actual"> 絹 </measure> ・ <measure ana="#調" commodity="#糸"
                 corresp="#阿波国" type="actual"> 糸 </measure> 、 <lb/> 庸、 <measure ana="#庸" commodity="#白木韓櫃" corresp="#阿波国"
                 type="actual"> 白木韓櫃 <measure quantity="12"> 十二 <unit unitRef="#合_set"> 合 </unit>
@@ -6855,7 +6855,7 @@
               </measure> 、 <measure ana="#中男作物" commodity="#紙" corresp="#讃岐国" type="actual"> 紙 </measure> 、 <measure
                 ana="#中男作物" commodity="#胡麻油" corresp="#讃岐国" type="actual"> 胡麻油 </measure> 、 <measure ana="#中男作物"
                 commodity="#乾鮹" corresp="#讃岐国" type="actual"> 乾鮹 </measure> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00035.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00035.tif/full/full/0/default.jpg"/>
               <measure ana="#中男作物" commodity="#鯛楚割" corresp="#讃岐国" type="actual"> 鯛楚割 </measure> 、 <measure ana="#中男作物"
                 commodity="#大鰯鮨" corresp="#讃岐国" type="actual"> 大鰯鮨 </measure> 、 <measure ana="#中男作物" commodity="#鯖"
                 corresp="#讃岐国" type="actual"> 鯖 </measure> 、 <measure ana="#中男作物" commodity="#海藻" corresp="#讃岐国"
@@ -6976,7 +6976,7 @@
             <head ana="大宰府"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24106501 engishiki_v24_ja.xml#item24106501" xml:id="item24106501"
                 ><placeName corresp="#西海道"> 西海道 </placeName><pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00036.tif/full/full/0/default.jpg"
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00036.tif/full/full/0/default.jpg"
                 /><lb/><orgName corresp="#大宰府"> 大宰府 </orgName> 〈行程、上廿七日、下十四日、〉海路卅日、 </p>
           </div>
           <div ana="主計上" corresp="engishiki_v24_en.xml#article241066 engishiki_v24_ja.xml#article241066" n="24.66" type="条"
@@ -7127,7 +7127,7 @@
               <note> 蒲　壬本・京博本「薄」。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00037.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00037.tif/full/full/0/default.jpg"/>
           <div ana="主計上" corresp="engishiki_v24_en.xml#article241067 engishiki_v24_ja.xml#article241067" n="24.67" type="条"
             xml:id="article241067">
             <head ana="筑後国"/>
@@ -7239,7 +7239,7 @@
                     <unit unitRef="#疋"> 疋 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#貲布" corresp="#肥後国" type="actual"> 貲布 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00038.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00038.tif/full/full/0/default.jpg"/>
                 <measure quantity="37"> 卅七 <unit unitRef="#端_調布"> 端 </unit>
                 </measure>
               </measure> 、 <measure ana="#調" commodity="#調布" corresp="#肥後国" type="actual"> 布 <measure quantity="120"> 一百廿
@@ -7350,7 +7350,7 @@
             <head ana="豊後国"/>
             <p ana="項" corresp="engishiki_v24_en.xml#item24107101 engishiki_v24_ja.xml#item24107101" xml:id="item24107101"
                 ><placeName corresp="#豊後国"> 豊後国 </placeName> 〈行程、上四日、下二日、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00039.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00039.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#糸" corresp="#豊後国" type="actual"> 糸 <measure ana="Weight" quantity="48"
                     ><anchor xml:id="app2410710101"/> 卌 <anchor xml:id="app2410710101e"/> 八 <unit unitRef="#絇"> 絇 </unit>
                 </measure>
@@ -7456,7 +7456,7 @@
             <p ana="項" corresp="engishiki_v24_en.xml#item24107401 engishiki_v24_ja.xml#item24107401" xml:id="item24107401"
                 ><placeName corresp="#薩摩国"> 薩摩国 </placeName> 〈行程、上十 <anchor xml:id="app2410740101"/> 一 <anchor
                 xml:id="app2410740101e"/> 日、下六日、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00040.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00040.tif/full/full/0/default.jpg"/>
               <lb/> 調、 <measure ana="#調" commodity="#塩" corresp="#薩摩国" type="actual"> 塩 <measureGrp ana="Volume"><measure
                     quantity="3"> 三 <unit unitRef="#斛"> 斛 </unit>
                   </measure><measure quantity="3"> 三 <unit unitRef="#斗"> 斗 </unit>
@@ -7541,132 +7541,132 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-24/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-24">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4646" xml:id="page4646">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4647" xml:id="page4647">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4648" xml:id="page4648">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4649" xml:id="page4649">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4650" xml:id="page4650">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4651" xml:id="page4651">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4652" xml:id="page4652">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4653" xml:id="page4653">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4654" xml:id="page4654">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4655" xml:id="page4655">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4656" xml:id="page4656">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4657" xml:id="page4657">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4658" xml:id="page4658">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4659" xml:id="page4659">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4660" xml:id="page4660">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4661" xml:id="page4661">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4662" xml:id="page4662">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4663" xml:id="page4663">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4664" xml:id="page4664">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4665" xml:id="page4665">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4666" xml:id="page4666">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4667" xml:id="page4667">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4668" xml:id="page4668">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4669" xml:id="page4669">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4670" xml:id="page4670">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4671" xml:id="page4671">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4672" xml:id="page4672">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4673" xml:id="page4673">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4674" xml:id="page4674">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4675" xml:id="page4675">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4676" xml:id="page4676">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4677" xml:id="page4677">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4678" xml:id="page4678">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4679" xml:id="page4679">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4680" xml:id="page4680">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4681" xml:id="page4681">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00036.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4682" xml:id="page4682">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00037.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00037.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4683" xml:id="page4683">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00038.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00038.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4684" xml:id="page4684">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00039.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00039.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4685" xml:id="page4685">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00040.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00040.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4686" xml:id="page4686">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00041.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00041.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24/page4687" xml:id="page4687">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-24%2F00042.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-24/00042.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v25.xml
+++ b/TEI編集用/engishiki_v25.xml
@@ -1350,7 +1350,7 @@
     <body>
       <div ana="主計下" n="25" type="巻" xml:id="volume25">
         <div type="首題" xml:id="shudai25">
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00002.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00002.tif/full/full/0/default.jpg"/>
           <p xml:id="shudai2501"> 延喜式巻第廿五 </p>
         </div>
         <div ana="主計下" corresp="engishiki_v25_en.xml#protocol251 engishiki_v25_ja.xml#protocol251" n="25" type="式"
@@ -1368,7 +1368,7 @@
               帳、若名在後死帳不載死 <anchor xml:id="app2510010103"/> 亡 <anchor xml:id="app2510010103e"/> 帳者 <anchor
                 xml:id="app2510010104"/> 亦 <anchor xml:id="app2510010104e"/> 勘出之、次勘 <anchor xml:id="app2510010105"/> 神
                 <anchor xml:id="app2510010105e"/> ・寺・諸家 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00003.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00003.tif/full/full/0/default.jpg"/>
               <anchor xml:id="app2510010106"/> 封 <anchor xml:id="app2510010106e"/> 戸幷応定納官人数及賦物、即勘抄損益惣目、明年正月一日申 <orgName
                 corresp="#民部省"> 省 </orgName> 、訖勘造応給返抄之状送 <orgName corresp="#主税寮"> 主税寮 </orgName> 、即勘出挙帳之状、便録 <orgName
                 corresp="#主計寮"> 主計 </orgName> 状尾、官人署名返送、訖即申 <orgName corresp="#民部省"> 省 </orgName>
@@ -1527,7 +1527,7 @@
               <note> 丁　政事要略五七（四一八頁）この下に「皆」あり。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00004.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00004.tif/full/full/0/default.jpg"/>
           <div ana="主計下" corresp="engishiki_v25_en.xml#article251003 engishiki_v25_ja.xml#article251003" n="25.3" type="条"
             xml:id="article251003">
             <head ana="大帳返帳"/>
@@ -1595,7 +1595,7 @@
                 <orgName corresp="#大宰府"> 大宰 </orgName> 管内、 <placeName corresp="#筑前国"> 筑前 </placeName> ・ <placeName
                 corresp="#筑後国"> 筑後 </placeName> ・ <placeName corresp="#肥前国"> 肥前 </placeName> ・ <placeName corresp="#肥後国"> 肥後
               </placeName> ・ <placeName corresp="#豊前国"> 豊前 </placeName> ・ <placeName corresp="#豊後国"> 豊 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00005.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00005.tif/full/full/0/default.jpg"/>
                 後 </placeName> 等六箇国大帳・調帳者、准税帳令当国雑掌勘申、即附雑掌 <anchor xml:id="app2510090101"/> 収 <anchor xml:id="app2510090101e"
               /> 大帳返抄幷調帳損益等、朝集帳及自余国・島四度公文令 <orgName corresp="#大宰府"> 府 </orgName> 雑掌 <anchor xml:id="app2510090102"/> 勘
                 <anchor xml:id="app2510090102e"/> 之、 </p>
@@ -1656,7 +1656,7 @@
             <p ana="項" corresp="engishiki_v25_en.xml#item25101401 engishiki_v25_ja.xml#item25101401" xml:id="item25101401"> 凡
                 <orgName corresp="#馬寮"> 左馬寮 </orgName> 秣料米、 <placeName corresp="#近江国"> 近江国 </placeName> 百五十斛、 <placeName
                 corresp="#備前国"> 備前 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00006.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00006.tif/full/full/0/default.jpg"/>
                 国 </placeName> 大豆八十斛、 <orgName corresp="#馬寮"> 右馬寮 </orgName> 料、 <placeName corresp="#播磨国"> 播磨国 </placeName>
               米百五十斛、 <placeName corresp="#阿波国"> 阿波国 </placeName> 大豆八十斛、並以彼 <orgName corresp="#寮"> 寮 </orgName> 請文勘会 <anchor
                 xml:id="app2510140101"/> 抄 <anchor xml:id="app2510140101e"/> 帳、 </p>
@@ -1722,7 +1722,7 @@
             <head ana="義倉"/>
             <p ana="項" corresp="engishiki_v25_en.xml#item25102001 engishiki_v25_ja.xml#item25102001" xml:id="item25102001">
               凡輸義倉穀者、一位五斛、二位四斛、三位三斛、四位二斛、内五位一斛、外五位五斗、上 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00007.tif/full/full/0/default.jpg"/>
               上戸二斛、上中戸一斛六斗、上下戸一斛二斗、中上戸一斛、中 <anchor xml:id="app2510200101"/> 中 <anchor xml:id="app2510200101e"/> 戸八斗、其帳至
                 <orgName corresp="#主計寮"> 寮 </orgName> 即更造帳二通、〈一通申 <orgName corresp="#民部省"> 省 </orgName> 、一通留 <orgName
                 corresp="#主計寮"> 寮 </orgName> 、〉若有損去年、返却其帳、若応賑給者、国司熟量貧 <anchor xml:id="app2510200102"/> 乏 <anchor
@@ -1789,7 +1789,7 @@
             <head ana="塡納"/>
             <p ana="項" corresp="engishiki_v25_en.xml#item25102501 engishiki_v25_ja.xml#item25102501" xml:id="item25102501">
               凡去年勘出調庸物、令当年使咸皆塡 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00008.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00008.tif/full/full/0/default.jpg"/>
               納、即 <anchor xml:id="app2510250101"/> 放 <anchor xml:id="app2510250101e"/> 返抄、 </p>
             <app from="#app2510250101" to="#app2510250101e">
               <lem wit="#壬本 #京博本 #慶長本 #梵本"> 放 </lem>
@@ -1906,7 +1906,7 @@
             <p ana="項" corresp="engishiki_v25_en.xml#item25103201 engishiki_v25_ja.xml#item25103201" xml:id="item25103201">
               凡桑漆帳、率戸数有 <anchor xml:id="app2510320101"/> 欠 <anchor xml:id="app2510320101e"/> 者、 <anchor
                 xml:id="app2510320102"/> 返 <anchor xml:id="app2510320102e"/> 其帳令殖 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00009.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00009.tif/full/full/0/default.jpg"/>
               塡、 </p>
             <app from="#app2510320101" to="#app2510320101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #慶長本 #梵本"> 欠 </lem>
@@ -1979,7 +1979,7 @@
             <head ana="大帳"/>
             <p ana="項" corresp="engishiki_v25_en.xml#item25103701 engishiki_v25_ja.xml#item25103701" xml:id="item25103701">
               某国 <anchor xml:id="app2510370101"/> 司 <anchor xml:id="app2510370101e"/> 解申預計某年大帳事 <lb/> 国府〈在某郡、去京若干里、〉 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00010.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00010.tif/full/full/0/default.jpg"/>
               合管郡若干〈郷若干、〉 <lb/> 合管戸若干〈欠乗去年若干、〉 <lb/>
               <seg rendition="#indent"> 戸若干不課〈欠乗去年若干、〉 </seg>
               <lb/>
@@ -2015,7 +2015,7 @@
               <lb/>
               <seg rendition="#indent2"> 戸若干合差科 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00011.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00011.tif/full/full/0/default.jpg"/>
               管口若干〈欠乗去年若干、〉 <lb/>
               <seg rendition="#indent"> 口若干不課〈欠乗去年若干、〉 </seg>
               <lb/>
@@ -2047,7 +2047,7 @@
               <lb/>
               <seg rendition="#indent2"> 戸若干帳後除 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00012.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00012.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent3"> 戸若干死絶 </seg>
               <lb/>
               <seg rendition="#indent3"> 戸若干配流 </seg>
@@ -2084,7 +2084,7 @@
               <lb/>
               <seg rendition="#indent3"> 戸若干新篤疾 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00013.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00013.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent3"> 戸若干帳内 </seg>
               <lb/>
               <seg rendition="#indent3"> 戸若干新寡妻 </seg>
@@ -2124,7 +2124,7 @@
               <lb/>
               <seg rendition="#indent2"> 戸若干某国某郡割来口新 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00014.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00014.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent2"> 戸若干承継口旧 </seg>
               <lb/> 都合今年計帳新旧定見戸若干〈欠乗去年若干、〉 <lb/>
               <seg rendition="#indent"> 戸若干不課 </seg>
@@ -2158,7 +2158,7 @@
               <lb/>
               <seg rendition="#indent3"> 戸若干新 </seg>
               <lb/> 去年計帳定口若干 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00015.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00015.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent"> 口若干不課 </seg>
               <lb/>
               <seg rendition="#indent3"> 口若干死 <anchor xml:id="app2510370601"/> 亡 <anchor xml:id="app2510370601e"/>
@@ -2197,7 +2197,7 @@
               <lb/>
               <seg rendition="#indent2"> 口若干女 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00016.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00016.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent3"> 口若干妻妾 </seg>
               <lb/>
               <seg rendition="#indent3"> 口若干寡婦 </seg>
@@ -2235,7 +2235,7 @@
               <lb/>
               <seg rendition="#indent2"> 口若干見不輸 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00017.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00017.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent2"> 口若干見輸 </seg>
               <lb/>
               <seg rendition="#indent3"> 口若 <anchor xml:id="app2510370607"/> 干 <anchor xml:id="app2510370607e"/>
@@ -2274,7 +2274,7 @@
               <lb/>
               <seg rendition="#indent3"> 口若干寡婦 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00018.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00018.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent3"> 口若干隠首附 </seg>
               <lb/>
               <seg rendition="#indent4"> 姓名年若干 </seg>
@@ -2309,7 +2309,7 @@
               <lb/>
               <seg rendition="#indent3"> 口若干新 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00019.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00019.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent2"> 口若干男 </seg>
               <lb/>
               <seg rendition="#indent3"> 口若干内外初位長上 </seg>
@@ -2346,7 +2346,7 @@
               <lb/>
               <seg rendition="#indent3"> 口若干寡婦 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00020.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00020.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent2"> 口若干奴 </seg>
               <lb/>
               <seg rendition="#indent2"> 口若干婢 </seg>
@@ -2383,7 +2383,7 @@
               <lb/>
               <seg rendition="#indent6"> 口若干正丁 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00021.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00021.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent6"> 口若干次丁 </seg>
               <lb/>
               <seg rendition="#indent5"> 口若干遭喪 </seg>
@@ -2421,7 +2421,7 @@
               <lb/>
               <seg rendition="#indent6"> 口若干正丁 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00022.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00022.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent6"> 口若干次丁 </seg>
               <lb/>
               <seg rendition="#indent5"> 口若干牧子 </seg>
@@ -2460,7 +2460,7 @@
               <lb/>
               <seg rendition="#indent6"> 口若干正丁 </seg>
               <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00023.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00023.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent6"> 口若干次丁 </seg>
               <lb/>
               <seg rendition="#indent5"> 口若干兵士 </seg>
@@ -2688,81 +2688,81 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-25/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-25">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4688" xml:id="page4688">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4689" xml:id="page4689">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4690" xml:id="page4690">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4691" xml:id="page4691">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4692" xml:id="page4692">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4693" xml:id="page4693">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4694" xml:id="page4694">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4695" xml:id="page4695">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4696" xml:id="page4696">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4697" xml:id="page4697">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4698" xml:id="page4698">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4699" xml:id="page4699">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4700" xml:id="page4700">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4701" xml:id="page4701">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4702" xml:id="page4702">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4703" xml:id="page4703">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4704" xml:id="page4704">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4705" xml:id="page4705">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4706" xml:id="page4706">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4707" xml:id="page4707">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4708" xml:id="page4708">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4709" xml:id="page4709">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4710" xml:id="page4710">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4711" xml:id="page4711">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25/page4712" xml:id="page4712">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-25%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-25/00025.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v27.xml
+++ b/TEI編集用/engishiki_v27.xml
@@ -1340,7 +1340,7 @@
   <text>
     <body>
       <div ana="主税下" n="27" type="巻" xml:id="volume27">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai27">
           <p xml:id="shudai2701"> 延喜式巻第廿七</p>
         </div>
@@ -1357,7 +1357,7 @@
               <lb/><seg rendition="#indent3">不動若干石</seg>
               <lb/><seg rendition="#indent3">動用若干石</seg>
               <lb/><seg rendition="#indent2">粟穀若干石</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00003.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00003.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent3">不動若干石</seg>
               <lb/><seg rendition="#indent3">動用若干石</seg>
               <lb/><seg rendition="#indent2"><anchor xml:id="app2710010101"/>穎<anchor xml:id="app2710010101e"/>稲若干束</seg>
@@ -1377,7 +1377,7 @@
               <lb/><seg rendition="#indent3">新任国司四分之一料若干束</seg>
               <lb/><seg rendition="#indent4">某官位姓名若干束</seg>
               <lb/><seg rendition="#indent3">書生料若干束</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00004.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00004.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent">塡納勘出若干束</seg>
               <lb/><seg rendition="#indent2">依<orgName corresp="#太政官">太政官</orgName><anchor xml:id="app2710010104"/>其<anchor
                   xml:id="app2710010104e"/>年月日符塡納若干束</seg>
@@ -1398,7 +1398,7 @@
               <lb/><seg rendition="#indent3">死馬皮若干張〈張別若干尺、〉</seg>
               <lb/><seg rendition="#indent4">価若干束〈張別若干束、〉</seg>
               <lb/><seg rendition="#indent2">牧馬牛皮若干<anchor xml:id="app2710010107"/>張<anchor xml:id="app2710010107e"/></seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00005.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00005.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent3">馬皮若干張〈張別若干尺、〉</seg>
               <lb/><seg rendition="#indent4">価若干束〈張別若干束、〉</seg>
               <lb/><seg rendition="#indent3">牛皮若干張〈張別若干<anchor xml:id="app2710010108"/>尺<anchor xml:id="app2710010108e"
@@ -1417,7 +1417,7 @@
               <lb/><seg rendition="#indent3">不動若干石</seg>
               <lb/><seg rendition="#indent3">動用若<anchor xml:id="app2710010109"/>干<anchor xml:id="app2710010109e"/>石</seg>
               <lb/><seg rendition="#indent2">穎若干束</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00006.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00006.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent3">不動穀倉底敷若干束</seg>
               <lb/><seg rendition="#indent3">定若干束</seg>
               <lb/><seg rendition="#indent2">糒若干石</seg>
@@ -1436,7 +1436,7 @@
                   xml:id="app2710010112e"/>転読金剛般若経若講師年中供養等准此、各為一項、〉</seg>
               <lb/><seg rendition="#indent4">三宝布施糸若干絇価若干束</seg>
               <lb/><seg rendition="#indent4">僧<pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00007.tif/full/full/0/default.jpg"
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00007.tif/full/full/0/default.jpg"
                 />若干口尼若干口布施</seg>
               <lb/><seg rendition="#indent5">絹若干疋〈口別若干疋、〉価若干束〈疋別若干<anchor xml:id="app2710010113"/>束<anchor
                   xml:id="app2710010113e"/>、〉</seg>
@@ -1456,7 +1456,7 @@
               <lb/><seg rendition="#indent4">甲若干具　料若干束</seg>
               <lb/><seg rendition="#indent5">牛皮若干張〈具別若干張、〉</seg>
               <lb/><seg rendition="#indent6">価若干束〈張別若干束、諸色准此、各為一項、〉</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00008.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00008.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">横刀若干口　料若干束</seg>
               <lb/><seg rendition="#indent5">鞘料鹿皮若干張〈張別若干尺、〉</seg>
               <lb/><seg rendition="#indent6">価若干束〈張別若干束、諸色准此、各為一項、〉</seg>
@@ -1475,7 +1475,7 @@
               <lb/><seg rendition="#indent5">某物若干枚価若干束〈枚別若干束、諸色准此、各為一項、〉</seg>
               <lb/><seg rendition="#indent3">年料進上雑米料若干束</seg>
               <lb/><seg rendition="#indent4">勅旨米若干石料若干束〈諸色准此、各為一項、〉</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00009.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00009.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">運賃料若干束</seg>
               <lb/><seg rendition="#indent5">海路行程若干箇日〈向京若干日、還郷若干日、〉</seg>
               <lb/><seg rendition="#indent5">海船若干艘〈勝載若干石、〉従某津迄某津賃若干束〈石別若干束、〉</seg>
@@ -1496,7 +1496,7 @@
               <lb/><seg rendition="#indent3">貢上御馬若干疋</seg>
               <lb/><seg rendition="#indent4">飼秣若干束〈疋別若干束、諸色准此、各為一項、〉</seg>
               <lb/><seg rendition="#indent3"><anchor xml:id="app2710010122"/>駅<anchor xml:id="app2710010122e"/>馬若干疋</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00010.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00010.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">飼秣若干束〈疋別若干束、〉</seg>
               <lb/><seg rendition="#indent3">買立駅馬若干疋価若干束</seg>
               <lb/><seg rendition="#indent4">上馬若干疋〈疋別若干束、中・下馬准此、各為一項、〉</seg>
@@ -1517,7 +1517,7 @@
               <lb/><seg rendition="#indent6">作綜単若干日</seg>
               <lb/><seg rendition="#indent3">駅使幷将従単若干人〈主典已上若干人、史生若干人、<anchor xml:id="app2710010126"/>従<anchor
                   xml:id="app2710010126e"/>若干人、〉</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00011.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00011.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">食料若干束</seg>
               <lb/><seg rendition="#indent5">飯料若干束〈史生已上日若干把、従日若干把、〉</seg>
               <lb/><seg rendition="#indent4">塩若干斗〈史生已上日若干夕、従日若干夕、〉</seg>
@@ -1536,7 +1536,7 @@
               <lb/><seg rendition="#indent5">上下単若干人〈主典已上若干人、史生若干人、従若干人、〉</seg>
               <lb/><seg rendition="#indent3">伝使幷将従単若<anchor xml:id="app2710010131"/>干<anchor xml:id="app2710010131e"
                   />人〈主典已上若干人、史生若干人、従<pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00012.tif/full/full/0/default.jpg"
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00012.tif/full/full/0/default.jpg"
                 />若干人、〉</seg>
               <lb/><seg rendition="#indent4">食料若干束</seg>
               <lb/><seg rendition="#indent5">飯料若干束〈史生已上日若干把、従日若干把、〉</seg>
@@ -1555,7 +1555,7 @@
               <lb/><seg rendition="#indent3">巡行国司単若干人〈目已上若干人、史生若干人、従<anchor xml:id="app2710010134"/>若<anchor
                   xml:id="app2710010134e"/>干人、〉</seg>
               <lb/><seg rendition="#indent4">食料若干束</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00013.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00013.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent5">飯料若干束〈目已上日若干升、史生日若干合、〉</seg>
               <lb/><seg rendition="#indent4">塩若干斗〈目已上日若干升、史生日若干合、〉</seg>
               <lb/><seg rendition="#indent4">酒若干<anchor xml:id="app2710010135"/>斗<anchor xml:id="app2710010135e"
@@ -1574,7 +1574,7 @@
               <lb/><seg rendition="#indent3">依<orgName corresp="#太政官">太政官</orgName>符用若干束</seg>
               <lb/><seg rendition="#indent4">依某年月日符給某官位姓名禄料若干束</seg>
               <lb/><seg rendition="#indent5">絹若干疋価若干束〈疋別若干束、〉</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00014.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00014.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent5">綿若干屯価若干束〈屯別若干束、〉</seg>
               <lb/><seg rendition="#indent5">調布若干端価若干束〈端別若干束、〉</seg>
               <lb/><seg rendition="#indent5">鍬若干口価若干束〈口別若干束、〉</seg>
@@ -1594,7 +1594,7 @@
               <lb/><seg rendition="#indent2">穎若干束</seg>
               <lb/><seg rendition="#indent3">不動倉底敷若干束</seg>
               <lb/><seg rendition="#indent3">定若干束</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00015.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00015.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent2">糒若干石</seg>
               <lb/><seg rendition="#indent2">塩若干石〈<anchor xml:id="app2710010140"/>諸色准此、各為一項<anchor xml:id="app2710010140e"
                 />、〉</seg>
@@ -1615,7 +1615,7 @@
               <lb/><seg rendition="#indent3">空若干宇〈倉若<anchor xml:id="app2710010143"/>干<anchor xml:id="app2710010143e"
                 />、屋若干、〉</seg>
               <lb/><seg rendition="#indent">不動倉鑰若干勾〈鑰若干勾、匙若干隻、〉</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00016.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00016.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent">動用鑰若干勾</seg>
               <lb/><seg rendition="#indent">倉印若干面〈已上郡<anchor xml:id="app2710010144"/>亦<anchor xml:id="app2710010144e"
                 />准此、〉</seg>
@@ -1842,7 +1842,7 @@
               <lb/><seg rendition="#indent">定田若干町</seg>
               <lb/><seg rendition="#indent2">応輸租田若干町</seg>
               <lb/><seg rendition="#indent3">郡司職田若干町〈余雑色田准此、各為一項、〉</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00017.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00017.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent3">口分田若干町</seg>
               <lb/><seg rendition="#indent4">某国百姓若干町</seg>
               <lb/><seg rendition="#indent4">当土百姓若干町</seg>
@@ -1862,7 +1862,7 @@
               <lb/><seg rendition="#indent3">口分田若干町</seg>
               <lb/><seg rendition="#indent3"><anchor xml:id="app2710020103"/>墾<anchor xml:id="app2710020103e"
                 />田若干町〈余雑色田准此、各為一項、〉</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00018.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00018.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent2">応輸地子田若干町</seg>
               <lb/><seg rendition="#indent3">乗田若干町〈余雑色田准此、各為一項、〉</seg>
               <lb/><seg rendition="#indent2">応輸租田若干町</seg>
@@ -1881,7 +1881,7 @@
               <lb/><seg rendition="#indent6">神封戸若干烟</seg>
               <lb/><seg rendition="#indent8">租若干束</seg>
               <lb/><seg rendition="#indent7">某神封戸若干烟</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00019.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00019.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent8">租若干束</seg>
               <lb/><seg rendition="#indent6">寺家封戸若干烟</seg>
               <lb/><seg rendition="#indent8">租若干束</seg>
@@ -1900,7 +1900,7 @@
               <lb/><seg rendition="#indent2">損若干町</seg>
               <lb/><seg rendition="#indent4">乗田若干町〈余雑色田准此、各為一項、〉</seg>
               <lb/><seg rendition="#indent2">得若干町</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00020.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00020.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">闕郡司職田若干町</seg>
               <lb/><seg rendition="#indent4">乗田若干町〈余雑色田准此、各為一項、〉</seg>
               <lb/><seg rendition="#indent3">輸地子稲若干束</seg>
@@ -1950,7 +1950,7 @@
               <note>帳　土本等無し。九本、近本挿入書により補う。</note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00021.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00021.tif/full/full/0/default.jpg"/>
           <div ana="主税下" corresp="engishiki_v27_en.xml#article271003 engishiki_v27_ja.xml#article271003" n="27.3" type="条"
             xml:id="article271003">
             <head ana="青苗帳"/>
@@ -1971,7 +1971,7 @@
               <lb/><seg rendition="#indent4">神田若干</seg>
               <lb/><seg rendition="#indent7">毎色可録、</seg>
               <lb/><seg rendition="#indent3">定田若干</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00022.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00022.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">応輸租田若干</seg>
               <lb/><seg rendition="#indent5">口分田若干</seg>
               <lb/><seg rendition="#indent7">毎色可録、</seg>
@@ -1990,7 +1990,7 @@
               <lb/><seg rendition="#indent7">毎色可録、</seg>
               <lb/><seg rendition="#indent2">某郷戸主姓名戸田若干</seg>
               <lb/><seg rendition="#indent3">売口分田若干</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00023.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00023.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">某里某坪</seg>
               <lb/><seg rendition="#indent5">買人姓名</seg>
               <lb/><seg rendition="#indent3">見営田若干</seg>
@@ -2009,7 +2009,7 @@
               <lb/><seg rendition="#indent7">毎色可録、</seg>
               <lb/><seg rendition="#indent2">浪人姓名営田若干</seg>
               <lb/><seg rendition="#indent4">口分<anchor xml:id="app2710030102"/>田<anchor xml:id="app2710030102e"/>若干</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00024.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00024.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent5">某里某坪</seg>
               <lb/><seg rendition="#indent6">姓名戸田</seg>
               <lb/><seg rendition="#indent7">毎色可録、</seg>
@@ -2045,7 +2045,7 @@
               <lb/><seg rendition="#indent3">租田若干</seg>
               <lb/><seg rendition="#indent4">不堪佃田若干</seg>
               <lb/><seg rendition="#indent4">堪佃田若干</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00025.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00025.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent4">地子田<anchor xml:id="app2710040101"/>若<anchor xml:id="app2710040101e"/>干</seg>
               <lb/>右得管諸郡司解偁、云<anchor xml:id="app2710040102"/>云<anchor xml:id="app2710040102e"/>、国司巡検、仍注不堪佃田幷堪佃田申上如件、謹解、
                 <lb/><seg rendition="#indent5">年月日</seg>
@@ -2078,7 +2078,7 @@
               <lb/><seg rendition="#indent3">見損田若干</seg>
               <lb/><seg rendition="#indent3">五分已上損戸得田若干</seg>
               <lb/><seg rendition="#indent2">得田若干</seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00026.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00026.tif/full/full/0/default.jpg"/>
               <lb/><seg rendition="#indent3">租田若干</seg>
               <lb/><seg rendition="#indent3">地子田若干</seg>
               <lb/><seg rendition="#indent">八分已上戸若干烟</seg>
@@ -2145,90 +2145,90 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-27/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-27">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4762" xml:id="page4762">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4763" xml:id="page4763">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4764" xml:id="page4764">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4765" xml:id="page4765">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4766" xml:id="page4766">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4767" xml:id="page4767">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4768" xml:id="page4768">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4769" xml:id="page4769">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4770" xml:id="page4770">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4771" xml:id="page4771">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4772" xml:id="page4772">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4773" xml:id="page4773">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4774" xml:id="page4774">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4775" xml:id="page4775">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4776" xml:id="page4776">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4777" xml:id="page4777">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4778" xml:id="page4778">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4779" xml:id="page4779">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4780" xml:id="page4780">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4781" xml:id="page4781">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4782" xml:id="page4782">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4783" xml:id="page4783">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4784" xml:id="page4784">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4785" xml:id="page4785">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4786" xml:id="page4786">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4787" xml:id="page4787">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4788" xml:id="page4788">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27/page4789" xml:id="page4789">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-27%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-27/00028.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v29.xml
+++ b/TEI編集用/engishiki_v29.xml
@@ -1373,7 +1373,7 @@
   <text>
     <body>
       <div ana="刑部・判事・囚獄" n="29" type="巻" xml:id="volume29">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai29">
           <p xml:id="shudai2901"> 延喜式巻第廿九　〈 <orgName corresp="#刑部省"> 刑部 </orgName> 判事 <orgName corresp="#囚獄司"> 囚獄 </orgName>
             〉 </p>
@@ -1421,7 +1421,7 @@
               <note> 弘　土本・近本・壬本・京博本・慶長本・梵本無し。九本により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00003.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00003.tif/full/full/0/default.jpg"/>
           <div ana="刑部" corresp="engishiki_v29-1_en.xml#article291003 engishiki_v29-1_ja.xml#article291003" n="29-1.3"
             type="条" xml:id="article291003">
             <head ana="訴訟人"/>
@@ -1554,7 +1554,7 @@
               <note> 弘　土本・近本・壬本・京博本・慶長本・梵本無し。九本により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00004.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00004.tif/full/full/0/default.jpg"/>
           <div ana="刑部" corresp="engishiki_v29-1_en.xml#article291013 engishiki_v29-1_ja.xml#article291013" n="29-1.13"
             type="条" xml:id="article291013">
             <head ana="無罪合免"/>
@@ -1647,7 +1647,7 @@
               <note> 三　筑波寛文本朱傍書「二〈式部式〉」。考異「式部式作二省」。延喜式部式下40毀位記条「二」。但し弘仁式部式「三」。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00005.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00005.tif/full/full/0/default.jpg"/>
           <div ana="刑部" corresp="engishiki_v29-1_en.xml#article291018 engishiki_v29-1_ja.xml#article291018" n="29-1.18"
             type="条" xml:id="article291018">
             <head ana="遠近"/>
@@ -1719,7 +1719,7 @@
                 ><anchor xml:id="app2910200101"/><anchor xml:id="app2910200101e"/><anchor xml:id="app2910200102"/> 凡 <anchor
                 xml:id="app2910200102e"/> 弁官所下罪人到 <orgName corresp="#刑部省"> 省 </orgName> 、付 <orgName corresp="#囚獄司"> 囚獄司
               </orgName> 、 <orgName corresp="#囚獄司"> 司 </orgName> 即易其 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00006.tif/full/full/0/default.jpg"/> 徽
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00006.tif/full/full/0/default.jpg"/> 徽
                 <anchor xml:id="app2910200103"/> 纆 <anchor xml:id="app2910200103e"/> 、其有行決者、随罪軽重、於 <orgName corresp="#市司"> 市
               </orgName> 若 <orgName corresp="#囚獄司"> 囚獄司 </orgName> 決之、行決之日、丞・録各一人、引 <orgName corresp="#囚獄司"> 囚獄 </orgName>
               官人并物部丁、赴向 <orgName corresp="#市司"> 市司 </orgName> 、便令本 <orgName corresp="#市司"> 司 </orgName> 喚集市 <anchor
@@ -1859,7 +1859,7 @@
             <p ana="項" corresp="engishiki_v29_en.xml#item29102801 engishiki_v29_ja.xml#item29102801" xml:id="item29102801"
                 ><anchor xml:id="app2910280101"/><anchor xml:id="app2910280101e"/> 凡宣良賤判者、卿引録以上、列於西行、大判事引属以上、列於東行、 <orgName
                 corresp="#囚獄司"> 囚獄司 </orgName> 一人当両頭 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00007.tif/full/full/0/default.jpg"/>
               中間二許丈却立、次主若寺檀越一許丈却立、次賤男東列跪、賤女西列跪、物部丁挟立於賤東西、自朝堂会昌門入、各如前列、卿已下当修式堂東北角列立、大判事已下当暉章堂西北角列立、並北向、各立定、当宣判事、自中間進二 <anchor
                 xml:id="app2910280102"/> 許 <anchor xml:id="app2910280102e"/> 丈、宣告判状、畢還立 <anchor xml:id="app2910280103"/> 本列
                 <anchor xml:id="app2910280103e"/> 、若判為良者、主若檀越并 <orgName corresp="#囚獄司"> 囚獄司 </orgName> 、西側避立、即 <orgName
@@ -1969,7 +1969,7 @@
             </app>
           </div>
         </div>
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00008.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00008.tif/full/full/0/default.jpg"/>
         <div ana="判事" corresp="engishiki_v29_en.xml#protocol292 engishiki_v29_ja.xml#protocol292" n="29-2" type="式"
           xml:id="protocol292">
           <div type="式題" xml:id="shikidai292">
@@ -2089,7 +2089,7 @@
               <note> 弘　土本・近本・壬本・京博本・慶長本・梵本無し。九本により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00009.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00009.tif/full/full/0/default.jpg"/>
           <div ana="囚獄" corresp="engishiki_v29-3_en.xml#article293002 engishiki_v29-3_ja.xml#article293002" n="29-3.2"
             type="条" xml:id="article293002">
             <head ana="着鈦盤枷"/>
@@ -2205,7 +2205,7 @@
             <head ana="物部"/>
             <p ana="項" corresp="engishiki_v29_en.xml#item29300901 engishiki_v29_ja.xml#item29300901" xml:id="item29300901">
               凡物部十人、申 <orgName corresp="#刑部省"> 省 </orgName> 移 <orgName corresp="#式部省"> 式部 </orgName> 、勘籍補之、其物 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00010.tif/full/full/0/default.jpg"/>
               部丁八人、准諸司直丁給粮、 </p>
           </div>
         </div>
@@ -2251,42 +2251,42 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-29/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-29">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4822" xml:id="page4822">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4823" xml:id="page4823">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4824" xml:id="page4824">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4825" xml:id="page4825">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4826" xml:id="page4826">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4827" xml:id="page4827">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4828" xml:id="page4828">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4829" xml:id="page4829">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4830" xml:id="page4830">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4831" xml:id="page4831">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4832" xml:id="page4832">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29/page4833" xml:id="page4833">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-29%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-29/00012.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v32.xml
+++ b/TEI編集用/engishiki_v32.xml
@@ -1360,7 +1360,7 @@
   <text>
     <body>
       <div ana="大膳上" n="32" type="巻" xml:id="volume32">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai32">
           <p xml:id="shudai3201"> 延喜式巻第卅二 </p>
         </div>
@@ -1377,7 +1377,7 @@
               口、白米五斗、糯米二斗、大豆・小豆各五升、酒二斗、塩一升、東鰒十二斤、島鰒・熬海鼠・蛸・雑腊各六斤、堅魚九斤、雑鮨六十斤、海菜十二斤、食薦四枚、祝史料庸布二段、 <lb/> 醤院高部神一座 <lb/> 竈神四座 <lb/>
               五色薄絁各二尺、倭文一尺、木綿・麻各八両、緋帛五尺、〈蓋料、〉鍬一口、白米三斗、糯米一斗、大豆・小豆各三升、酒一斗、塩六升、雑鰒二斤、堅魚・熬海鼠・腊各六斤、雑鮨十六斤、煮塩年魚十二斤、海藻四斤、祝史料商布二段、
               <lb/> 菓餅所火雷神一座 <lb/> 五色薄絁各三尺、倭文一尺、木綿・麻各八両、鍬一口、白米三斗、糯米一斗、大豆・小豆各三升、酒一斗、塩六升、雑鰒二斤、堅魚・雑腊各六斤、雑鮨十一斤、海藻四斤、祝史料商布二段、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00003.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00003.tif/full/full/0/default.jpg"/>
               <lb/> 竈神四座 <lb/> 五色薄絁各三尺、倭文二尺、木綿・麻各八 <anchor xml:id="app3210010102"/> 両 <anchor xml:id="app3210010102e"/>
               、鍬四口、白米二斗、糯米一斗、大豆・小豆各二升、酒一斗、塩四升、雑鰒二斤、堅魚・腊各六斤、鮨五斤、海藻四斤、 <lb/>
               <seg rendition="#indent2"> 右、四祭春料依前件、秋亦准此、但御膳神二月・十一月上酉日祭之、 </seg>
@@ -1402,7 +1402,7 @@
             <head ana="神今食"/>
             <p ana="項" corresp="engishiki_v32_en.xml#item32100201 engishiki_v32_ja.xml#item32100201" xml:id="item32100201">
               六月神今食、 <anchor xml:id="app3210020101"/> 十二月准此 <anchor xml:id="app3210020101e"/> 、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00004.tif/full/full/0/default.jpg"/>
               <lb/> 輿籠四脚、〈納供神物、〉簀四枚、〈置供物料、〉槲二俵、〈供神料、〉 <lb/>
               小斎給食惣二百六十二人、〈五位已上廿人、六位已下二百人、命婦十人、女孺・采女合廿七人、御巫五人、〉五位已上一人、醤・酢各五夕、塩一合、東鰒二両、堅魚・烏賊各一両、熬海鼠・腊各二両、雑鮨九両、鯖三両、海藻二両、漬菜二合、六位已下一人、醤五夕、塩五夕、東鰒二両、堅魚一両、熬海鼠二両、鯖一両、鮨七両、海藻二両、漬菜二合、〈
                 <anchor xml:id="app3210020102"/> 皇 <anchor xml:id="app3210020102e"/> 后宮小斎六位官人已下采女 <anchor
@@ -1440,7 +1440,7 @@
                 xml:id="app3210030105e"/> 升、干柿子一升二合、橘子二蔭、〈已上七種、 <anchor xml:id="app3210030106"/> 神 <anchor
                 xml:id="app3210030106e"/> 四座菓餅料、自余不須 <anchor xml:id="app3210030107"/> 也 <anchor xml:id="app3210030107e"/>
               、〉酒四座別【瓦+嬰】一口、〈各受一斗、〉四座別坩一口、〈各受五升、〉大直神一缶、〈受五升、〉木綿二分四銖、麁筥十三合、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00005.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00005.tif/full/full/0/default.jpg"/>
               〈各長一尺四寸、広一尺二寸、深三寸、〉食薦五枚、〈居神筥料、〉輿籠二脚、〈納筥料、〉置簀二枚、檞二俵、 <lb/>
               <seg rendition="#indent"> 右、 <orgName corresp="#大膳職"> 職 </orgName>
                 <orgName corresp="#造酒司"> 司 </orgName> 料理与 <orgName corresp="#神祇官"> 神祇官 </orgName> 供之、 </seg>
@@ -1508,7 +1508,7 @@
               <anchor xml:id="app3210040201"/> 人 <anchor xml:id="app3210040201e"/>
               別糯米七合五夕、大豆七夕、小豆一合五夕、韲酒三夕、酢一合、醤二合、塩二合九夕、東鰒一両二分、 <placeName corresp="#隠伎国"> 隠伎 </placeName>
               鰒四両二分、堅魚二両一分二銖、烏賊二両、熬海鼠三両二分、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00006.tif/full/full/0/default.jpg"/>
               与理刀魚五両、鮭二分隻之一、雑魚楚割三両、堅魚煎汁一両一分、鮨二斤四両、腊十両、 <anchor xml:id="app3210040202"/> 紫 <anchor xml:id="app3210040202e"/>
               菜・海松各三分、海藻二両、漬菜二合、漬蒜房・蒜英・韮搗各二合、滓醤二合、生栗子五合、搗栗子二合五夕、干柿子一合五夕、橘子十五顆、木綿二分四銖、 </p>
             <app from="#app3210040201" to="#app3210040201e">
@@ -1558,7 +1558,7 @@
             <head ana="新嘗祭"/>
             <p ana="項" corresp="engishiki_v32_en.xml#item32100501 engishiki_v32_ja.xml#item32100501" xml:id="item32100501">
               新嘗祭 <lb/> 輿籠二脚、置簀二枚、〈並供神料、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00007.tif/full/full/0/default.jpg"/>
               <lb/> 小斎給食惣三百卅四人、〈五位已上廿人、六位已下二百五十五人、命婦十人、女孺・采女卌四人、御巫五人、〉 <lb/> 五位已上一人、 <anchor xml:id="app3210050101"/> 醤
                 <anchor xml:id="app3210050101e"/> ・酢・塩各一合、東鰒七両、堅魚一両、烏賊十二両、熬海鼠・腊各五両、鮨八両、海藻十二両、漬蒜房・蒜英各二合、漬菜一合、韮搗二合、 <lb/>
               六位已下一人、醤五夕、塩五夕、東鰒七両、熬海鼠・腊各五両、海藻四両、鮨六両、韮搗五夕、漬菜一合、 <lb/>
@@ -1599,7 +1599,7 @@
               同会皇后宮小斎人卌二人、〈命婦并女孺廿人、駕輿丁已上十六人、外記已下 <orgName corresp="#主水司"> 主水 </orgName> 官人已上六人、〉 <lb/> 五位一人、醤五夕、塩一合、東 <anchor
                 xml:id="app3210070102"/> 鰒 <anchor xml:id="app3210070102e"/> 七両、烏賊十二両、熬海鼠五両、腊五両、海藻四両、漬 <anchor
                 xml:id="app3210070103"/> 蒜 <anchor xml:id="app3210070103e"/> 房并蒜花・韮搗 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00008.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00008.tif/full/full/0/default.jpg"/>
               各二 <anchor xml:id="app3210070104"/> 合 <anchor xml:id="app3210070104e"/> 、 <lb/>
               六位已下一人、醤・塩各五夕、東鮑六両、熬海鼠四両、鮨六両、鯖三両二分、海藻四両、 <lb/> 同宮神態直相給食卌七人、〈后宮亮一人、進已下諸 <orgName corresp="#衛府"> 衛府 </orgName>
               舎人已上卌六人、〉 <lb/> 五位一人、醤五夕、塩一合二夕、東 <anchor xml:id="app3210070105"/> 鮑 <anchor xml:id="app3210070105e"/>
@@ -1672,7 +1672,7 @@
               <note place="傍"> 京博本朱傍書「 <seg rendition="#shu"> 顆イ </seg> 」 </note>
               <note> 果　訳注本は九本により「顆」に改める。京博本朱傍書「顆イ」。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00009.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00009.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v32_en.xml#item32100802 engishiki_v32_ja.xml#item32100802" xml:id="item32100802">
               四位五位并命婦 <lb/> 人別餅料粳米・糯米各四合、糯糒一合、糖一合 <anchor xml:id="app3210080201"/> 五 <anchor xml:id="app3210080201e"/>
               夕、小麦二合、大豆・小豆各一合、胡麻子一合、油 <anchor xml:id="app3210080202"/> 一合 <anchor xml:id="app3210080202e"/> 、韲酒・酢各 <anchor
@@ -1727,7 +1727,7 @@
               <rdg wit="#土本 #近本 #壬本 #京博本 #慶長本 #梵本"/>
               <note> 一　土本・近本・壬本・京博本・慶長本・梵本無し。九本により補う。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00010.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00010.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v32_en.xml#item32100805 engishiki_v32_ja.xml#item32100805" xml:id="item32100805">
               <anchor xml:id="app3210080502"/>
               <anchor xml:id="app3210080502e"/>
@@ -1813,7 +1813,7 @@
                 xml:id="app3210090302"/> 䕑 <anchor xml:id="app3210090302e"/> 五升、蘭十把、蔓菁六斗、葵二斗、〈已上十種、 <orgName corresp="#内膳司">
                 内膳司 </orgName> 所進、〉 <anchor xml:id="app3210090303"/> 竹 <anchor xml:id="app3210090303e"/> 卌株、〈 <placeName
                 corresp="#山城国"> 山城国 </placeName> 所進、〉鮮魚充直、〈鮮魚・菓子直布六端、自余諸祭同料、不注布数 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00011.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00011.tif/full/full/0/default.jpg"/>
               皆放此、〉糖八升、松明八十把、炭二斛、薪三百六十斤、〈松明以下直、〉官人当色一領、膳部六人明衣、 <placeName corresp="#佐渡国"> 佐渡 </placeName> 布、人別二丈一尺、 </p>
             <app from="#app3210090301" to="#app3210090301e">
               <lem wit="#土本 #九本 #近本 #壬本 #京博本 #慶長本 #梵本"> 芸 </lem>
@@ -1891,7 +1891,7 @@
             </app>
             <p ana="項" corresp="engishiki_v32_en.xml#item32101003 engishiki_v32_ja.xml#item32101003" xml:id="item32101003">
               饌案十脚、〈冬加五脚、〉覆・敷 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00012.tif/full/full/0/default.jpg"/>
               料曝布廿条、〈覆長各六尺、敷長各五尺、〉上・中折櫃各六十合、〈冬加卅合、〉上折櫃敷料調布六十条、〈長各三尺、〉大笥百合、〈冬同、〉絹篩二口、〈別二尺五寸、冬同、〉燈油三升五合、〈冬同、〉覆瓫柏一千把、〈冬加百把、〉干柏五俵、〈冬同、〉陶大盤・叩盆各十口、〈冬同、〉筥坏卅口、〈冬加十口、〉由加三口、〈冬同、〉食薦八十枚、〈冬同、〉箸竹七十株、〈冬同、〉鮮魚・菓子、〈充直、〉拭料商布三条、〈別四尺、
                 <anchor xml:id="app3210100301"/> 冬 <anchor xml:id="app3210100301e"/> 同、〉膳部 <anchor xml:id="app3210100302"/> 官
                 <anchor xml:id="app3210100302e"/> 人・今良雇夫合卅二人、襷・襅料商布人別九尺、〈冬加八人料、〉駆使雇夫単五十人食料黒米、人日二升、塩二夕、功直、〈随時、〉 </p>
@@ -1919,7 +1919,7 @@
               鰒・煮堅魚各五斤四両、雑平魚・雑魚楚割各七斤十四両、鯖百十三隻、海藻十六斤二両、塩八升五合九夕、醤四升二合、酢・韲酒各一升、滓醤三升、醤滓一升五合、生栗子一斗六升八合、搗栗子八升四合、干柿子十連半、芋子八升四合、笋子廿一把、折櫃卌二合、大笥廿五合、
                 <anchor xml:id="app3210110102"/> 覆 <anchor xml:id="app3210110102e"/> ・敷折櫃廿一合料調布一端二丈一尺、薪五荷、炭五斗、青柏六俵、 <anchor
                 xml:id="app3210110103"/> 味 <anchor xml:id="app3210110103e"/> 物・菓子、〈直布五端、〉干柏二 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00013.tif/full/full/0/default.jpg"/>
               俵、平坏二百五十二口、窪坏・韲坏各八十四口、食薦卌枚、筯竹一囲、炬油二升、 <anchor xml:id="app3210110104"/> 白米三斗、〈膳部等食料、〉夫十五人、〈 <orgName
                 corresp="#京職"> 京職 </orgName> 所進、〉 <anchor xml:id="app3210110104e"/> 黒米一斗八升、〈夫食料、〉 </p>
             <app from="#app3210110101" to="#app3210110101e">
@@ -1986,7 +1986,7 @@
               白米二斛、〈五斗贄使粮料、一斛膳部間食料、一斗漿水料、四斗祭料、〉酢・醤各一斗五升、塩三斗五升、東鰒卅七斤、 <placeName corresp="#隠伎国"><anchor xml:id="app3210130102"
                 /> 隠岐 <anchor xml:id="app3210130102e"/>
               </placeName> 鰒・堅魚各卅七斤、縄貫鰒廿八斤、煮堅魚・熬海鼠各廿九斤、雑䐹卅四斤、蛸廿五斤、鳥賊廿七斤、鮭六十四隻半、雑腊百廿八斤、鯖百廿斤、雑鮨五缶、堅魚 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00014.tif/full/full/0/default.jpg"/>
               煎汁三升、雑海菜五升、海藻六十二斤、芥子三升、合盛雑腊一籠、 <lb/> 覆敷案料信濃布四端三丈、敷折櫃一百 <anchor xml:id="app3210130103"/> 合 <anchor
                 xml:id="app3210130103e"/> 布七端二丈三尺、大笥一百合、蒜一斗四升、葱三斗、蘿菔七十把、萵苣七斗、葵三斗、芹三斗、蕓薹三斗、胡 <anchor xml:id="app3210130104"/>
               䕑 <anchor xml:id="app3210130104e"/> 五升、蘭十把、〈已上九種、 <orgName corresp="#内膳司"> 内膳司 </orgName> 所進、〉弓弦葉廿七担、 <anchor
@@ -2040,7 +2040,7 @@
             <p ana="項" corresp="engishiki_v32_en.xml#item32101501 engishiki_v32_ja.xml#item32101501" xml:id="item32101501"
                 ><anchor xml:id="app3210150101"/><anchor xml:id="app3210150101e"/> 松尾神祭雑給料 <lb/>
               折櫃卌五合、大笥卌三合、東鰒十斤、熬海鼠・烏賊各十六斤五両、雑鮨・腊各六十四斤十二両、雑平魚廿一斤、鮭八隻半、鯖卌斤、芥子一 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00015.tif/full/full/0/default.jpg"/>
               升、海藻廿斤六両、塩一斗一升六合二夕、醤五升一合、韲酒・酢各 <anchor xml:id="app3210150102"/> 五 <anchor xml:id="app3210150102e"/>
               升七合、〈机別二合、折櫃別一合、〉陶大盤・叩戸各五口、調布三端九尺、〈折櫃敷料各三尺、〉曝布 <anchor xml:id="app3210150103"/> 一端二丈六尺 <anchor
                 xml:id="app3210150103e"/> 、〈机敷料別五尺、覆料別六尺、〉篩料絹三尺、商布五 <anchor xml:id="app3210150104"/> 段 <anchor
@@ -2118,7 +2118,7 @@
                 xml:id="app3210160102"/> 醢 <anchor xml:id="app3210160102e"/> 一升、魚 <anchor xml:id="app3210160103"/> 醢 <anchor
                 xml:id="app3210160103e"/> 一升、兔 <anchor xml:id="app3210160104"/> 醢 <anchor xml:id="app3210160104e"/>
               一升、豚胉一升、鹿五蔵一升、脾析葅一升、羊脯十三斤八両、〈代用鹿脯、〉糯米四升、大豆・ <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00016.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00016.tif/full/full/0/default.jpg"/>
               胡麻子・乾棗子各二升、黍子四升、栗黄一斗一升、榛人・菱人・芡人・韮葅・蔓菁葅・芹 <anchor xml:id="app3210160105"/> 葅 <anchor xml:id="app3210160105e"/>
               ・笋葅各二升、葵葅九 <anchor xml:id="app3210160106"/> 升 <anchor xml:id="app3210160106e"/>
               、塩一升五合、醤三升、三牲宍各一頭、鹿一斗五升、〈大羹料、〉鹿一斗、〈 <anchor xml:id="app3210160107"/> 醢 <anchor xml:id="app3210160107e"/> 料、〉 </p>
@@ -2208,7 +2208,7 @@
               <note> 柄　土本・近本・壬本・京博本・慶長本・梵本「両」。九本により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00017.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00017.tif/full/full/0/default.jpg"/>
           <div ana="大膳上" corresp="engishiki_v32_en.xml#article321019 engishiki_v32_ja.xml#article321019" n="32.19" type="条"
             xml:id="article321019">
             <head ana="六衛府輪転"/>
@@ -2248,60 +2248,60 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-32/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-32">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4890" xml:id="page4890">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4891" xml:id="page4891">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4892" xml:id="page4892">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4893" xml:id="page4893">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4894" xml:id="page4894">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4895" xml:id="page4895">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4896" xml:id="page4896">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4897" xml:id="page4897">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4898" xml:id="page4898">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4899" xml:id="page4899">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4900" xml:id="page4900">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4901" xml:id="page4901">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4902" xml:id="page4902">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4903" xml:id="page4903">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4904" xml:id="page4904">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4905" xml:id="page4905">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4906" xml:id="page4906">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32/page4907" xml:id="page4907">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-32%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-32/00018.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v37.xml
+++ b/TEI編集用/engishiki_v37.xml
@@ -1371,7 +1371,7 @@
     <body>
       <div ana="典薬" type="巻" xml:id="volume37">
         <div type="首題" xml:id="shudai37">
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00002.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00002.tif/full/full/0/default.jpg"/>
           <p xml:id="shudai3701"> 延喜式巻第卅七 </p>
         </div>
         <div ana="典薬" corresp="engishiki_v37_ja.xml#protocol371 engishiki_v37_en.xml#protocol371" n="37" type="式"
@@ -1468,7 +1468,7 @@
               <anchor xml:id="app3710010204"/> 張、木綿三分、所須人参七両三分、甘草六両二分、桂 <anchor xml:id="app3710010204e"/> 心三分、〈請 <orgName
                 corresp="#内蔵寮"> 内蔵寮 </orgName> 、〉白朮二両三分、 <anchor xml:id="app3710010205"/> 大黄 <anchor xml:id="app3710010205e"
               /> 一両二分、附子三両二分、 <anchor xml:id="app3710010206"/> 蜀 <anchor xml:id="app3710010206e"/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00003.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00003.tif/full/full/0/default.jpg"/>
               <anchor xml:id="app3710010207"/> 椒 <anchor xml:id="app3710010207e"/> 二両二分、 <anchor xml:id="app3710010208"/> 防風
                 <anchor xml:id="app3710010208e"/>
               <anchor xml:id="app3710010209"/> 三 <anchor xml:id="app3710010209e"/> 分、烏頭 <anchor xml:id="app3710010210"/> 一両二分
@@ -1645,7 +1645,7 @@
                   xml:id="app3710010402"/> 挙 <anchor xml:id="app3710010402e"/> 案退却、 <anchor xml:id="app3710010403"/> 即
                   <anchor xml:id="app3710010403e"/>
                 <anchor xml:id="app3710010404"/> 付 <anchor xml:id="app3710010404e"/> 尚薬、但屠蘇者、官人将薬生、同日午 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00004.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00004.tif/full/full/0/default.jpg"/>
                 時封 <anchor xml:id="app3710010405"/> 漬 <anchor xml:id="app3710010405e"/> 御井、令 <orgName corresp="#主水司"> 主水司
                 </orgName> 守、元日寅一刻、官人率薬生、就井出薬、即 <orgName corresp="#省"> 省 </orgName> 輔一人并 <orgName corresp="#寮"> 寮 </orgName>
                 官人等、持薬共入進置、即用銀鎗子煖 <anchor xml:id="app3710010406"/> 酒漬 <anchor xml:id="app3710010406e"/> 屠蘇、〈 <orgName
@@ -1781,7 +1781,7 @@
                 xml:id="app3710020301e"/> 六両、防葵四両、 <anchor xml:id="app3710020302"/> 黄連 <anchor xml:id="app3710020302e"/> 十両、
                 <anchor xml:id="app3710020303"/> 夕 <anchor xml:id="app3710020303e"/> 薬九両 <anchor xml:id="app3710020304"/> 三
                 <anchor xml:id="app3710020304e"/> 分、亭 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00005.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00005.tif/full/full/0/default.jpg"/>
               歴子九両、 <anchor xml:id="app3710020305"/> 杏 <anchor xml:id="app3710020305e"/> 人十二両、茈胡八両、大黄二斤十五両二分、烏頭十両、紫菀二両、呉茱萸二両、
                 <anchor xml:id="app3710020306"/> 昌 <anchor xml:id="app3710020306e"/> 蒲二両、厚朴二両、桔梗二両、 <anchor
                 xml:id="app3710020307"/> 皂莢 <anchor xml:id="app3710020307e"/> 二両、 <anchor xml:id="app3710020308"/> 伏 <anchor
@@ -1885,7 +1885,7 @@
               <note> 斎　土本・近本・壬本・京博本・梵本・慶長本「斉」。版本に従い改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00006.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00006.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371003 engishiki_v37_ja.xml#article371003" n="37.3" type="条"
             xml:id="article371003">
             <head ana="中宮臘月御薬"/>
@@ -1912,7 +1912,7 @@
                 xml:id="app3710030208"/> 蒴 <anchor xml:id="app3710030208e"/> 藋二両、商陸二両、𦬣草一斤三両、升麻一両二分、黄耆二両、茈胡二両、地楡二両、 <anchor
                 xml:id="app3710030209"/> 牡 <anchor xml:id="app3710030209e"/> 丹二両、大戟三両二分、 <anchor xml:id="app3710030210"/> 夕
                 <anchor xml:id="app3710030210e"/> 薬六両三分、玄参一両三分、白頭公一両二分、支子二分、蛇銜一両、独活一両、生地黄五両、薤白廿茎、松脂一両二分、竜 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00007.tif/full/full/0/default.jpg"/>
               骨一両二分、青木香三両、白 <anchor xml:id="app3710030211"/> 微 <anchor xml:id="app3710030211e"/> 二両二分、躑躅花三両、甘葛煎小一斗一升一合、 </p>
             <app from="#app3710030201" to="#app3710030201e">
               <lem wit="#土本 #近本 #壬本 #京博本 #梵本 #慶長本"> 昌 </lem>
@@ -2056,7 +2056,7 @@
               <rdg wit="#近本 #壬本"> 上 </rdg>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00008.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00008.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371005 engishiki_v37_ja.xml#article371005" n="37.5" type="条"
             xml:id="article371005">
             <head ana="白散"/>
@@ -2189,7 +2189,7 @@
             <p ana="項" corresp="engishiki_v37_en.xml#item37100601 engishiki_v37_ja.xml#item37100601" xml:id="item37100601">
               雑給料 <lb/> 四味理仲丸廿剤、七気丸十三剤、干薑丸七剤、烏梅丸廿剤、呉茱萸丸三剤、当帰丸十剤、 <anchor xml:id="app3710060101"/> 夕 <anchor
                 xml:id="app3710060101e"/> 薬丸十剤、神明膏三剤、大万病膏三剤、千瘡万病膏 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00009.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00009.tif/full/full/0/default.jpg"/>
               三剤、駐車丸十剤、牽牛子丸五剤、黄連丸四剤、十三物呵唎勒丸二剤、大黄膏二剤、升麻膏三剤、 </p>
             <app from="#app3710060101" to="#app3710060101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #梵本 #慶長本"> 夕 </lem>
@@ -2206,7 +2206,7 @@
                 <anchor xml:id="app3710060207e"/> 六両、白薟十二両、蒴藋一斤二両、商陸六両、𦬣草九両、升麻十三両二分、黄耆六両、地楡六両、牡丹六両、大戟十両二分、 <anchor
                 xml:id="app3710060208"/> 夕 <anchor xml:id="app3710060208e"/> 薬一斤十三両 <anchor xml:id="app3710060209"/> 三
                 <anchor xml:id="app3710060209e"/> 分、玄参五両一分、白頭公四両二分、支子人百五十枚、蛇銜十二両、独活三両、生地黄十五 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00010.tif/full/full/0/default.jpg"/>
               両、 <anchor xml:id="app3710060210"/> 薤 <anchor xml:id="app3710060210e"/> 白五十二茎、橘皮九両、芒消一斤四両、 <anchor
                 xml:id="app3710060211"/> 狗 <anchor xml:id="app3710060211e"/> 脊一両二分、牽牛子三斤十三両、 <anchor xml:id="app3710060212"/>
               亭 <anchor xml:id="app3710060212e"/> 歴子一斤四両、漏芦六 <anchor xml:id="app3710060213"/> 両 <anchor
@@ -2305,7 +2305,7 @@
                 xml:id="app3710070105e"/> 綱熟麻廿斤、〈随損請受、〉調布潔褠五条、〈別六尺、〉 <anchor xml:id="app3710070106"/> 襅 <anchor
                 xml:id="app3710070106e"/> 五条、〈別六尺、〉手巾一条、〈長五尺、〉燈油六升、酌煎匏三柄、沫 <anchor xml:id="app3710070107"/> 籮 <anchor
                 xml:id="app3710070107e"/> 二口、納汁由加六合、盛煎陶壺十六合、〈受大五升已上、〉受絞汁叩盆六口、盛様煎陶椀一合、〈加盤、〉麻笥三口、杓三柄、紙十六張、〈覆壺口料、〉結固壺口木綿 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00011.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00011.tif/full/full/0/default.jpg"/>
               大一斤、薪二千四百斤、炭廿石、 </p>
             <app from="#app3710070101" to="#app3710070101e">
               <lem wit="#土本 #近本 #壬本 #梵本 #慶長本"> 泉 </lem>
@@ -2397,7 +2397,7 @@
               乳夫三人潔衫各三丈六尺袴七尺料、一端三丈一尺同 <anchor xml:id="app3710110107"/> 夫 <anchor xml:id="app3710110107e"/>
               <anchor xml:id="app3710110108"/> 三 <anchor xml:id="app3710110108e"/> 人小袖二条別四尺、襅二条別五尺、拭陶鉢布三条別三尺、水篩二口別四尺、頭巾二条別三尺、
                 <anchor xml:id="app3710110109"/> 巾 <anchor xml:id="app3710110109e"/> 二条別三尺、繋牛足布一丈、懸牛腹布七尺、拭乳布三条 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00012.tif/full/full/0/default.jpg"/>
               別三尺料、〉生糸九両、〈縫篩并夫等衣・袴料、〉陶鉢五口、平瓶・壺各二口、陶叩盆・由加・瓼・洗盤各一口、高案二脚、 <anchor xml:id="app3710110110"/> 明 <anchor
                 xml:id="app3710110110e"/> 櫃二合、中取案一脚、木蓋二枚、〈並取乳料、〉槽一隻、〈飼牛粥料、〉油一升、〈十二月 <anchor xml:id="app3710110111"/> 晦
                 <anchor xml:id="app3710110111e"/> 料、〉薪日別一百五十斤、〈煮牛粥料、〉乳牛七頭秣料米・大豆各 <anchor xml:id="app3710110112"/> 日 <anchor
@@ -2505,7 +2505,7 @@
                 xml:id="app3710140103"/> 料 <anchor xml:id="app3710140103e"/>
               帛二疋、絹篩四条、〈別五尺、〉調布二端、〈帷四条料、条別二丈、〉縫糸三両、上紙卌張、明櫃四合、水麻笥四口、〈受五斗已上、〉杓三柄、簀二枚、長席二張、〈女医座、〉由加四口、酒槽二隻、中取二脚、〈已上三種随損請替、〉
                 <anchor xml:id="app3710140104"/> 共 <anchor xml:id="app3710140104e"/> 作女医十四 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00013.tif/full/full/0/default.jpg"/>
               人、人別日飯一升、塩一夕、滓 <anchor xml:id="app3710140105"/> 醤 <anchor xml:id="app3710140105e"/> 一合、酒三合、並限卅日給、 </p>
             <app from="#app3710140101" to="#app3710140101e">
               <lem wit="#近本 #壬本 #京博本 #梵本 #慶長本"> 申 </lem>
@@ -2611,7 +2611,7 @@
             <head ana="斎宮寮雑薬"/>
             <p ana="項" corresp="engishiki_v37_en.xml#item37101801 engishiki_v37_ja.xml#item37101801" xml:id="item37101801">
               諸司年料雑薬 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00014.tif/full/full/0/default.jpg"/>
               <lb/>
               <orgName corresp="#斎宮寮"> 斎宮寮 </orgName> 五十三種 <lb/> 芒消七両四銖、防風一両二分四銖、麻黄二両三分四銖、蛇銜九両一分、石膏一両 <anchor
                 xml:id="app3710180101"/> 三 <anchor xml:id="app3710180101e"/> 分、芎藭七両三分、大黄一斤四両二分四銖、人参十両、紫菀二両二分、 <anchor
@@ -2733,7 +2733,7 @@
               <note> 抜　訳注本は正格の用字である「菝」に改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00015.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00015.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371019 engishiki_v37_ja.xml#article371019" n="37.19" type="条"
             xml:id="article371019">
             <head ana="内匠寮雑薬"/>
@@ -2833,7 +2833,7 @@
               防己各十両、半夏・桔梗・紫菀・皂莢各五両、石膏・蛇銜各三両、 <anchor xml:id="app3710210104"/> 茈 <anchor xml:id="app3710210104e"/> 胡・桃人・
                 <anchor xml:id="app3710210105"/> 夕 <anchor xml:id="app3710210105e"/> 薬・黄耆・秦 <anchor xml:id="app3710210106"/>
               膠 <anchor xml:id="app3710210106e"/> ・連翹・青木香・芦茹・牡丹・牛 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00016.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00016.tif/full/full/0/default.jpg"/>
               膝各八両、呉茱萸・ <anchor xml:id="app3710210107"/> 伏 <anchor xml:id="app3710210107e"/> 苓・白芷・熟 <anchor
                 xml:id="app3710210108"/> 艾 <anchor xml:id="app3710210108e"/> ・甘遂各一斤八両、 <anchor xml:id="app3710210109"/> 昌
                 <anchor xml:id="app3710210109e"/> 蒲・亭歴子各四両、芎藭一斤五両、烏頭四斤、黄芩・黄連・防風・前胡・枳子・茵芋・黄蘗各十四両、杏 <anchor
@@ -2925,7 +2925,7 @@
               苓八両、細辛十両三分、蜀椒一斤十両二分、 <anchor xml:id="app3710220105"/> 夕 <anchor xml:id="app3710220105e"/> 薬・亭 <anchor
                 xml:id="app3710220106"/> 歴 <anchor xml:id="app3710220106e"/> 子・杏人・厚朴各四両、芎藭一 <anchor xml:id="app3710220107"/>
               斤 <anchor xml:id="app3710220107e"/> 二両二分、白朮十二両二分、当帰八両二分、黄芩四両三分、麻黄三両、黄 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00017.tif/full/full/0/default.jpg"/>
               連・皂莢・𦬣草各二分、前胡十一両二分、麹一斤二両、 <lb/>
               <seg rendition="#indent"> 右、府別白散 <anchor xml:id="app3710220108"/> 卌 <anchor xml:id="app3710220108e"/> 八剤、
                   <anchor xml:id="app3710220109"/> 伏 <anchor xml:id="app3710220109e"/> 苓散・百毒散各三剤、七気丸・ <anchor
@@ -3075,7 +3075,7 @@
             <head ana="兵庫寮雑薬"/>
             <p ana="項" corresp="engishiki_v37_en.xml#item37102501 engishiki_v37_ja.xml#item37102501" xml:id="item37102501"
                 ><orgName corresp="#兵庫寮"> 兵庫寮 </orgName> 四種 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00018.tif/full/full/0/default.jpg"/>
               <lb/> 神明膏・万病膏・ <anchor xml:id="app3710250101"/> 伏 <anchor xml:id="app3710250101e"/>
               苓散各一剤、百毒散半剤、其料桂心・干薑各二両二分、猪膏廿斤、酢九升一合、篩料絹二尺、絞料調布四尺、裹薬料紙四張、木綿一両、陶壺二口、炭五斗、申 <orgName corresp="#省"> 省 </orgName> 請受、 </p>
             <app from="#app3710250101" to="#app3710250101e">
@@ -3106,7 +3106,7 @@
               胡・烏頭・附子・天雄・商陸・蜀椒・黄耆・松脂・石南草各六斤、大戟・防己・黄蘗・紫菀・苦参・ <anchor xml:id="app3710270105"/> 昌 <anchor
                 xml:id="app3710270105e"/> 蒲各四斤、石韋・沢写・玄参・稾本・熟 <anchor xml:id="app3710270106"/> 艾 <anchor
                 xml:id="app3710270106e"/> ・ <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00019.tif/full/full/0/default.jpg"/>
               漏芦・【艹/閭】 <anchor xml:id="app3710270107"/> 茹 <anchor xml:id="app3710270107e"/> ・甘遂・蛇銜・ <anchor
                 xml:id="app3710270108"/> 梨 <anchor xml:id="app3710270108e"/>
               芦・干地黄・枳実・桑根白皮・丹参各二斤、杏人・五味子・兎糸子・亭歴子・蛇床子・半夏・蒲黄・麦門冬・僕奈各四斤、練胡麻一斗六升、桃 <anchor xml:id="app3710270109"/> 人 <anchor
@@ -3206,7 +3206,7 @@
               草薬八十種 <lb/> 練胡麻大五升、桃人一斗四升、黄芩・ <anchor xml:id="app3710290101"/> 薺 <anchor xml:id="app3710290101e"/>
               <anchor xml:id="app3710290102"/> 苨 <anchor xml:id="app3710290102e"/> ・黄連・白朮・石斛・藍 <anchor xml:id="app3710290103"
               /> 漆 <anchor xml:id="app3710290103e"/> ・細辛・桔梗・独活・当帰・夜干・牛 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00020.tif/full/full/0/default.jpg"/>
               膝・ <anchor xml:id="app3710290104"/> 伏 <anchor xml:id="app3710290104e"/>
               苓・白芷・升麻・橘皮・附子・烏頭・天雄・黄耆・松脂・石南草・防己・黄蘗・白薟・紫菀・麦門冬・ <anchor xml:id="app3710290105"/> 苦 <anchor
                 xml:id="app3710290105e"/> 参・鬼臼・芎藭・干地黄・枳実・葛根各二斤、 <anchor xml:id="app3710290106"/> 夕 <anchor
@@ -3361,7 +3361,7 @@
               <note> 伏　訳注本は正格の用字である「茯」に改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00021.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00021.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371031 engishiki_v37_ja.xml#article371031" n="37.31" type="条"
             xml:id="article371031">
             <head ana="新羅使草薬"/>
@@ -3497,7 +3497,7 @@
                 <placeName corresp="#諸国"> 諸国 </placeName> 医師公廨、人 <anchor xml:id="app3710360101"/> 別 <anchor
                 xml:id="app3710360101e"/> 所給十分之一、毎年 <anchor xml:id="app3710360102"/> 割 <anchor xml:id="app3710360102e"/>
               留随国所出交易軽物、附貢調使送之、若有未進 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00022.tif/full/full/0/default.jpg"/> 移
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00022.tif/full/full/0/default.jpg"/> 移
                 <orgName corresp="#主計寮"> 主計寮 </orgName> 、令 <anchor xml:id="app3710360103"/> 拘 <anchor xml:id="app3710360103e"
               /> 使返抄、但侍医并医・針博士兼任及非業者、不在此限、 </p>
             <app from="#app3710360101" to="#app3710360101e">
@@ -3631,7 +3631,7 @@
             <p ana="項" corresp="engishiki_v37_en.xml#item37104201 engishiki_v37_ja.xml#item37104201" xml:id="item37104201">
               凡味原牛 <anchor xml:id="app3710420101"/> 牧 <anchor xml:id="app3710420101e"/> 死牛皮者、売用 <orgName corresp="#典薬寮"> 寮
               </orgName> 修理料、但所売 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00023.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00023.tif/full/full/0/default.jpg"/>
               得数、附年終帳申送之、 </p>
             <app from="#app3710420101" to="#app3710420101e">
               <lem wit="#慶安版本 #明暦版本 #寛文版本 #享保版本"> 牧 </lem>
@@ -3684,7 +3684,7 @@
               朴十八斤、白薟二斤二両、葛根卅二斤、鼠尾草三斤、桃人 <anchor xml:id="app3710450107"/> 九 <anchor xml:id="app3710450107e"/> 升、杏 <anchor
                 xml:id="app3710450108"/> 人 <anchor xml:id="app3710450108e"/> 一斗八 <anchor xml:id="app3710450109"/> 升 <anchor
                 xml:id="app3710450109e"/> 、赤小豆四斗六升、蜀椒一斗二升、鼈甲一枚、白粟大 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00024.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00024.tif/full/full/0/default.jpg"/>
               一斗、 </p>
             <app from="#app3710450101" to="#app3710450101e">
               <lem wit="#壬本 #京博本 #梵本 #慶長本"> 畿 </lem>
@@ -3811,7 +3811,7 @@
                 xml:id="app3710470111e"/> ・地楡・桑 <anchor xml:id="app3710470112"/> 螵 <anchor xml:id="app3710470112e"/>
               蛸各二斤、桃花十両、夜干五斤、茜根一斤、蜂房七両、兎糸子二升、 <anchor xml:id="app3710470113"/> 署預 <anchor xml:id="app3710470113e"/>
               六升、桃人一升、車前子・亭歴 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00025.tif/full/full/0/default.jpg"/>
               子・蓼子・蜀椒各三升、荏子二升五合、 <anchor xml:id="app3710470114"/> 胡麻子 <anchor xml:id="app3710470114e"/>
               各四升五合、杏人一斗九升、鼈甲四枚、鹿角四具、葵子大五升、 <anchor xml:id="app3710470115"/> 枸 <anchor xml:id="app3710470115e"/> 杞六斤、 </p>
             <app from="#app3710470101" to="#app3710470101e">
@@ -3961,7 +3961,7 @@
                 xml:id="app3710500105"/> 卌 <anchor xml:id="app3710500105e"/> 三斤、人参 <anchor xml:id="app3710500106"/> 二 <anchor
                 xml:id="app3710500106e"/> 斤八両、【艹/五】茄十六斤六両、躑躅花十斤、 <anchor xml:id="app3710500107"/> 杜 <anchor
                 xml:id="app3710500107e"/> 仲十五斤、白芷卅四斤、細辛十一斤、栝楼十九 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00026.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00026.tif/full/full/0/default.jpg"/>
               斤、木 <anchor xml:id="app3710500108"/> 斛 <anchor xml:id="app3710500108e"/> 廿斤、白 <anchor xml:id="app3710500109"/>
               微 <anchor xml:id="app3710500109e"/> 一斤四両、松脂十六斤、大戟五斤四両、地楡十五斤十両、楡皮五斤、厚朴十九斤八両、 <anchor xml:id="app3710500110"/> 伏
                 <anchor xml:id="app3710500110e"/> 苓十一斤十両、蜂房一斤十二両、升麻 <anchor xml:id="app3710500111"/> 卌 <anchor
@@ -4046,7 +4046,7 @@
                 <anchor xml:id="app3710510107e"/> 、 <anchor xml:id="app3710510108"/> 榧 <anchor xml:id="app3710510108e"/> 子四斗、
                 <anchor xml:id="app3710510109"/> 署預 <anchor xml:id="app3710510109e"/> ・海蛤各一斗、麦門冬四升、桃人二斗九升六合、蛇床子一升、兎 <anchor
                 xml:id="app3710510110"/> 糸 <anchor xml:id="app3710510110e"/> 子・紫蘇子各五升、山茱萸大 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00027.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00027.tif/full/full/0/default.jpg"/>
               一斗五升、亭歴子二升、半夏大五升、蜀椒二斗五升八合、青木 <anchor xml:id="app3710510111"/> 香 <anchor xml:id="app3710510111e"/> 十八斤、 </p>
             <app from="#app3710510101" to="#app3710510101e">
               <lem wit="#近本訂正書 #慶安版本 #明暦版本 #寛文版本 #享保版本"> 枸 </lem>
@@ -4209,7 +4209,7 @@
               <note> 零　訳注本は正格の用字である「羚」に改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00028.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00028.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371055 engishiki_v37_ja.xml#article371055" n="37.55" type="条"
             xml:id="article371055">
             <head ana="伊豆年料雑薬"/>
@@ -4323,7 +4323,7 @@
                 xml:id="app3710570111"/> 斗 <anchor xml:id="app3710570111e"/> 、亭 <anchor xml:id="app3710570112"/> 歴 <anchor
                 xml:id="app3710570112e"/> 子五合、石 <anchor xml:id="app3710570113"/> 流 <anchor xml:id="app3710570113e"/>
               黄一斗、猪蹄一具、丹参四斤、 <anchor xml:id="app3710570114"/> 豉 <anchor xml:id="app3710570114e"/> 大五 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00029.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00029.tif/full/full/0/default.jpg"/>
               斗、 </p>
             <app from="#app3710570101" to="#app3710570101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #慶長本"> 廿斤 </lem>
@@ -4482,7 +4482,7 @@
               杞・木防己各十斤、杜仲・地楡各四斤、瞿麦・ <anchor xml:id="app3710600104"/> 貝子 <anchor xml:id="app3710600104e"/> 各三斤、 <anchor
                 xml:id="app3710600105"/> 伏 <anchor xml:id="app3710600105e"/> 苓廿八斤、葛花・旋 <anchor xml:id="app3710600106"/> 復
                 <anchor xml:id="app3710600106e"/> 花各二斤、白鮮六斤、蒲黄四斤、榧子二斗二 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00030.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00030.tif/full/full/0/default.jpg"/>
               升、 <anchor xml:id="app3710600107"/> 署預 <anchor xml:id="app3710600107e"/> 四斗、麦門冬一斗四升、桃人 <anchor
                 xml:id="app3710600108"/> 六 <anchor xml:id="app3710600108e"/> 斗、附子八斗、莨蓎子一升、 <anchor xml:id="app3710600109"/> 升
                 <anchor xml:id="app3710600109e"/> 麻三斤、 </p>
@@ -4608,7 +4608,7 @@
               <note> 署預　訳注本は正格の用字である「薯蕷」に改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00031.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00031.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371063 engishiki_v37_ja.xml#article371063" n="37.63" type="条"
             xml:id="article371063">
             <head ana="近江年料雑薬"/>
@@ -4638,7 +4638,7 @@
               <anchor xml:id="app3710630124"/> 一 <anchor xml:id="app3710630124e"/> 両、蛇脱皮一両、干地黄一斗二升、 <anchor
                 xml:id="app3710630125"/> 榧 <anchor xml:id="app3710630125e"/> 子五斗、 <anchor xml:id="app3710630126"/> 署預 <anchor
                 xml:id="app3710630126e"/> ・桃 <anchor xml:id="app3710630127"/> 人 <anchor xml:id="app3710630127e"/> 各一斗、麦門冬一斗五
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00032.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00032.tif/full/full/0/default.jpg"
               /> 升五合、天雄・烏頭・牡荊子各六升、決明子二 <anchor xml:id="app3710630128"/> 升 <anchor xml:id="app3710630128e"/>
               、蛇床子二升二合、莨蓎子一升、葵子四升、車前子八升、呉茱萸三斗、蜀椒二升、白花木瓜実十斤、山茱萸 <anchor xml:id="app3710630129"/> 二升 <anchor
                 xml:id="app3710630129e"/> 、 </p>
@@ -4879,7 +4879,7 @@
               </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00033.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00033.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371065 engishiki_v37_ja.xml#article371065" n="37.65" type="条"
             xml:id="article371065">
             <head ana="飛騨年料雑薬"/>
@@ -4985,7 +4985,7 @@
                 ><placeName corresp="#下野国"> 下野国 </placeName> 十四種 <lb/> 青木香廿斤、芎藭十五斤、枸杞二斤八両、黄菊花五両、藍漆九斤、石 <anchor
                 xml:id="app3710680101"/> 斛 <anchor xml:id="app3710680101e"/> 廿斤、秦 <anchor xml:id="app3710680102"/> 膠 <anchor
                 xml:id="app3710680102e"/> 十六斤、干地黄・桃人・烏頭各二斗、附子四斗、決明子一斗、牡荊子八升、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00034.tif/full/full/0/default.jpg"/> 石
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00034.tif/full/full/0/default.jpg"/> 石
                 <anchor xml:id="app3710680103"/> 流 <anchor xml:id="app3710680103e"/> 黄二斗三升、 </p>
             <app from="#app3710680101" to="#app3710680101e">
               <lem wit="#近本 #壬本 #京博本 #梵本 #慶長本"> 斛 </lem>
@@ -5107,7 +5107,7 @@
               僕奈四斤 <anchor xml:id="app3710720102e"/> 、細辛五斤、大黄廿六斤、升麻 <anchor xml:id="app3710720103"/> 六斤 <anchor
                 xml:id="app3710720103e"/> 、夜干廿斤、黄精十二両、榧子一斗六升、 <anchor xml:id="app3710720104"/> 署預 <anchor
                 xml:id="app3710720104e"/> 二斗、桃人七升五合、兎糸子四升、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00035.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00035.tif/full/full/0/default.jpg"/>
               蜀椒二斗七升、 </p>
             <app from="#app3710720101" to="#app3710720101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #梵本 #慶長本"> 昌 </lem>
@@ -5220,7 +5220,7 @@
             <head ana="丹波年料雑薬"/>
             <p ana="項" corresp="engishiki_v37_en.xml#item37107801 engishiki_v37_ja.xml#item37107801" xml:id="item37107801"
                 ><placeName corresp="#山陰道"> 山陰道 </placeName><lb/><placeName corresp="#丹波国"> 丹波国 </placeName> 卌三種 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00036.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00036.tif/full/full/0/default.jpg"/>
               <lb/> 芎藭・石 <anchor xml:id="app3710780101"/> 葦 <anchor xml:id="app3710780101e"/>
               ・栝楼・石南草・升麻・夜干各十斤、黄連三斤二両、前胡・稾本・秦皮各五斤、 <anchor xml:id="app3710780102"/> 茈 <anchor xml:id="app3710780102e"/>
               胡十二斤、王不留行十九斤、独活卅四斤、 <anchor xml:id="app3710780103"/> 䓡苺 <anchor xml:id="app3710780103e"/> 五斤、萆 <anchor
@@ -5300,7 +5300,7 @@
               <anchor xml:id="app3710790104"/> 断 <anchor xml:id="app3710790104e"/> 各十斤、白芷十斤、 <anchor xml:id="app3710790105"/>
               伏 <anchor xml:id="app3710790105e"/> 苓七斤三両、升麻二斤八両、蛇脱皮二両、榧子一斗一升、 <anchor xml:id="app3710790106"/> 署預 <anchor
                 xml:id="app3710790106e"/> 一斗、麦門冬大一斗三升五合、桃人一斗五升、車前子一斗六升、亭歴子二升三合、呉茱萸・蜀椒各一斗七 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00037.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00037.tif/full/full/0/default.jpg"/>
               升、乾棗一斗、細辛十五斤、甘葛煎三升、白殭 <anchor xml:id="app3710790107"/> 蝅 <anchor xml:id="app3710790107e"/> 二両、 </p>
             <app from="#app3710790101" to="#app3710790101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #梵本 #慶長本"> 廿四種 </lem>
@@ -5456,7 +5456,7 @@
                 xml:id="app3710820101e"/>
               <lb/> 独活十二斤、藍漆四斤、牛膝五斤、白朮十斤、 <anchor xml:id="app3710820102"/> 昌 <anchor xml:id="app3710820102e"/>
               蒲・桑根白皮各一斤、薺苨三斤、杜仲・ <anchor xml:id="app3710820103"/> 伏 <anchor xml:id="app3710820103e"/> 苓・紫菀各二斤、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00038.tif/full/full/0/default.jpg"/> 石
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00038.tif/full/full/0/default.jpg"/> 石
                 <anchor xml:id="app3710820104"/> 斛 <anchor xml:id="app3710820104e"/> 廿四斤、松 <anchor xml:id="app3710820105"/> 羅
                 <anchor xml:id="app3710820105e"/> 一斤、升麻九斤、榧子二石六斗、 <anchor xml:id="app3710820106"/> 署預 <anchor
                 xml:id="app3710820106e"/> 九升、呉茱萸三斗九升、蜀椒九升、桃人七升、百合一斗一升、 </p>
@@ -5545,7 +5545,7 @@
             <p ana="項" corresp="engishiki_v37_en.xml#item37108401 engishiki_v37_ja.xml#item37108401" xml:id="item37108401"
                 ><placeName corresp="#石見国"> 石見国 </placeName> 十四種 <lb/> 前胡一斤四両、独活・ <anchor xml:id="app3710840101"/> 伏 <anchor
                 xml:id="app3710840101e"/> 苓各六 <anchor xml:id="app3710840102"/> 斤 <anchor xml:id="app3710840102e"/> 、牛膝・栝楼・白朮
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00039.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00039.tif/full/full/0/default.jpg"
               /> 各三斤、藍 <anchor xml:id="app3710840103"/> 漆 <anchor xml:id="app3710840103e"/> 一斤十五両、黄蘗四斤、細辛・当帰各十五斤、桑螵蛸九両、射干一斤、
                 <anchor xml:id="app3710840104"/> 署預 <anchor xml:id="app3710840104e"/> 一斗二升、蜀椒 <anchor xml:id="app3710840105"
               /> 三 <anchor xml:id="app3710840105e"/> 斗五升、 </p>
@@ -5666,7 +5666,7 @@
               <note> 鹿　土本・壬本・京博本・梵本「麻」。近本「麻」に作り「鹿」と訂正書。慶長本により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00040.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00040.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371086 engishiki_v37_ja.xml#article371086" n="37.86" type="条"
             xml:id="article371086">
             <head ana="美作年料雑薬"/>
@@ -5737,7 +5737,7 @@
               /> 夕 <anchor xml:id="app3710870103e"/> 薬・地楡・升麻・馬刀各三斤、桔梗 <anchor xml:id="app3710870104"/> 五十斤 <anchor
                 xml:id="app3710870104e"/> 、薺苨・竜胆・白頭公各二斤、 <anchor xml:id="app3710870105"/> 昌 <anchor xml:id="app3710870105e"/>
               蒲一斤、黄耆九斤、𦬣草十一両、商陸四斗、漏芦七斤、松脂六斤、大戟・牡丹・天門冬・桑螵蛸各一 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00041.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00041.tif/full/full/0/default.jpg"/>
               斤、榧子一斗五升、 <anchor xml:id="app3710870106"/> 署預 <anchor xml:id="app3710870106e"/>
               ・牡荊子各四升、麦門冬・秦椒各二升、桃人・車前子・亭歴子・蜀椒各六升、呉茱萸三斗、乾棗八升、白芷四 <anchor xml:id="app3710870107"/> 斤 <anchor
                 xml:id="app3710870107e"/> 、沢写十斤、白殭蚕二両、 </p>
@@ -5861,7 +5861,7 @@
             <p ana="項" corresp="engishiki_v37_en.xml#item37108901 engishiki_v37_ja.xml#item37108901" xml:id="item37108901"
                 ><placeName corresp="#備後国"> 備後国 </placeName> 廿八種 <lb/> 白頭公五斤、石斛卌九斤、桔梗卅五斤、白朮卅四斤六両、細辛卅斤、 <anchor
                 xml:id="app3710890101"/> 昌 <anchor xml:id="app3710890101e"/> 蒲四斤、黄蘗十斤、当帰六斤、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00042.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00042.tif/full/full/0/default.jpg"/>
               薺苨廿三斤、 <anchor xml:id="app3710890102"/> 夕 <anchor xml:id="app3710890102e"/> 薬二斤、木斛十五斤、 <anchor
                 xml:id="app3710890103"/> 伏 <anchor xml:id="app3710890103e"/> 苓五斤、升麻一斤、紫菀十三斤、夜干廿一斤、赤石脂三斤八両、桑螵蛸十両、 <anchor
                 xml:id="app3710890104"/> 署預 <anchor xml:id="app3710890104e"/> 一斗四升、麦門冬三斗六升、桃人一斗一升、車前子二斗三升、 <anchor
@@ -5975,7 +5975,7 @@
                 xml:id="app3710910101"/> 斤 <anchor xml:id="app3710910101e"/> 、苦参十斤、【艹/五】 <anchor xml:id="app3710910102"/> 茄
                 <anchor xml:id="app3710910102e"/> 四両、細辛一斤八両、巴戟天・ <anchor xml:id="app3710910103"/> 伏 <anchor
                 xml:id="app3710910103e"/> 苓各一斤、夜干卅斤八両、防己六斤、滑石 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00043.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00043.tif/full/full/0/default.jpg"/>
               廿斤、榧子五升、 <anchor xml:id="app3710910104"/> 署預 <anchor xml:id="app3710910104e"/> 八斗、麦門冬七升、桃人四升五合、呉茱萸四升、 </p>
             <app from="#app3710910101" to="#app3710910101e">
               <lem wit="#慶安版本 #明暦版本 #寛文版本 #享保版本"> 斤 </lem>
@@ -6104,7 +6104,7 @@
             <head ana="阿波年料雑薬"/>
             <p ana="項" corresp="engishiki_v37_en.xml#item37109401 engishiki_v37_ja.xml#item37109401" xml:id="item37109401"
                 ><placeName corresp="#阿波国"> 阿波国 </placeName> 卅三種 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00044.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00044.tif/full/full/0/default.jpg"/>
               <lb/> 茈胡・黄菊花・沢写・橘皮各一斤、萆 <anchor xml:id="app3710940101"/> 解 <anchor xml:id="app3710940101e"/> ・躑躅花・𦬣草各四 <anchor
                 xml:id="app3710940102"/> 斤 <anchor xml:id="app3710940102e"/> 、薺苨・ <anchor xml:id="app3710940103"/> 夕 <anchor
                 xml:id="app3710940103e"/> 薬・土瓜・ <anchor xml:id="app3710940104"/> 牡 <anchor xml:id="app3710940104e"/>
@@ -6233,7 +6233,7 @@
               <note> 升　土本・近本・壬本・京博本・梵本・慶長本・版本「斤」。雲本に従い改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00045.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00045.tif/full/full/0/default.jpg"/>
           <div ana="典薬" corresp="engishiki_v37_en.xml#article371096 engishiki_v37_ja.xml#article371096" n="37.96" type="条"
             xml:id="article371096">
             <head ana="伊予年料雑薬"/>
@@ -6382,7 +6382,7 @@
               <seg rendition="#indent"><anchor xml:id="app3710980201"/> 右 <anchor xml:id="app3710980201e"/> 、依前件附貢調使送
                   <orgName corresp="#典薬寮"> 寮 </orgName> 、検収 <anchor xml:id="app3710980202"/> 訖 <anchor
                   xml:id="app3710980202e"/> 即与返抄、 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00046.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00046.tif/full/full/0/default.jpg"/>
                 其 <orgName corresp="#大宰府"><anchor xml:id="app3710980203"/> 大 <anchor xml:id="app3710980203e"/> 宰 </orgName>
                 便附別貢使、 </seg>
             </p>
@@ -6504,147 +6504,147 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-37/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-37">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4986" xml:id="page4986">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4987" xml:id="page4987">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4988" xml:id="page4988">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4989" xml:id="page4989">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4990" xml:id="page4990">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4991" xml:id="page4991">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4992" xml:id="page4992">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4993" xml:id="page4993">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4994" xml:id="page4994">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4995" xml:id="page4995">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4996" xml:id="page4996">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4997" xml:id="page4997">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4998" xml:id="page4998">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page4999" xml:id="page4999">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5000" xml:id="page5000">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5001" xml:id="page5001">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5002" xml:id="page5002">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5003" xml:id="page5003">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5004" xml:id="page5004">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5005" xml:id="page5005">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5006" xml:id="page5006">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5007" xml:id="page5007">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5008" xml:id="page5008">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5009" xml:id="page5009">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5010" xml:id="page5010">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5011" xml:id="page5011">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5012" xml:id="page5012">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5013" xml:id="page5013">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5014" xml:id="page5014">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5015" xml:id="page5015">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5016" xml:id="page5016">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5017" xml:id="page5017">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5018" xml:id="page5018">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5019" xml:id="page5019">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5020" xml:id="page5020">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5021" xml:id="page5021">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00036.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5022" xml:id="page5022">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00037.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00037.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5023" xml:id="page5023">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00038.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00038.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5024" xml:id="page5024">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00039.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00039.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5025" xml:id="page5025">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00040.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00040.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5026" xml:id="page5026">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00041.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00041.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5027" xml:id="page5027">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00042.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00042.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5028" xml:id="page5028">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00043.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00043.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5029" xml:id="page5029">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00044.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00044.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5030" xml:id="page5030">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00045.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00045.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5031" xml:id="page5031">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00046.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00046.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37/page5032" xml:id="page5032">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-37%2F00047.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-37/00047.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v39.xml
+++ b/TEI編集用/engishiki_v39.xml
@@ -1342,9 +1342,9 @@
   </teiHeader>
   <text>
     <body>
-      <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00001.tif/full/full/0/default.jpg"/>
+      <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00001.tif/full/full/0/default.jpg"/>
       <div ana="正親・内膳" n="39" type="巻" xml:id="volume39">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai39">
           <p xml:id="shudai3901"> 延喜式巻第卅九 〈 <orgName corresp="#正親司"> 正親 </orgName>
             <orgName corresp="#内膳司"> 内膳 </orgName> 〉 </p>
@@ -1378,7 +1378,7 @@
               凡諸王計帳者、令造二通、 <orgName corresp="#正親司"> 司 </orgName> 加押署、 <orgName corresp="#京職"> 京職 </orgName> 判畢一通留 <orgName
                 corresp="#正親司"> 司 </orgName> 、待年足符、即勘会申 <orgName corresp="#宮内省"> 省 </orgName> 、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00003.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00003.tif/full/full/0/default.jpg"/>
           <div ana="正親" corresp="engishiki_v39_ja.xml#article391004 engishiki_v39_en.xml#article391004" n="39-1.4" type="条"
             xml:id="article391004">
             <head ana="同世同名"/>
@@ -1455,7 +1455,7 @@
             <head ana="平野祭"/>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39100901 engishiki_v39_en.xml#item39100901" xml:id="item39100901">
               凡参平野祭所官人并諸王見参歴名、進 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00004.tif/full/full/0/default.jpg"/>
               <orgName corresp="#太政官"> 太政官 </orgName> 、 </p>
           </div>
           <div ana="正親" corresp="engishiki_v39_ja.xml#article391010 engishiki_v39_en.xml#article391010" n="39-1.10" type="条"
@@ -1493,7 +1493,7 @@
         </div>
         <div ana="内膳" corresp="engishiki_v39_ja.xml#protocol392 engishiki_v39_en.xml#protocol392" n="39-2" type="式"
           xml:id="protocol392">
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00004.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00004.tif/full/full/0/default.jpg"/>
           <div type="式題" xml:id="shikidai392">
             <p xml:id="shikidai39201">
               <orgName corresp="#内膳司"> 内膳司 </orgName>
@@ -1522,7 +1522,7 @@
             <head ana="月日春祭"/>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39200301 engishiki_v39_en.xml#item39200301" xml:id="item39200301">
               月日春祭 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00005.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00005.tif/full/full/0/default.jpg"/>
               <lb/> 高案二脚、〈 <orgName corresp="#木工寮"> 木工寮 </orgName> 所充、〉調布四条、〈各長五尺、覆敷案料、〉陶高盤八口、筥瓶二口、飯笥二合、木綿小一斤、〈已上 <orgName
                 corresp="#内蔵寮"> 内蔵寮 </orgName> 所充、〉 <lb/>
               <seg rendition="#indent"> 右、雑物申請内侍、其供神物者、割取供奉月料雑物未御者料理、盛備高案送 <orgName corresp="#縫殿寮"> 縫殿寮 </orgName> 、秋祭准此、
@@ -1566,7 +1566,7 @@
             <head ana="神今食"/>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39200601 engishiki_v39_en.xml#item39200601" xml:id="item39200601">
               六月神今食料〈十二月准此、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00006.tif/full/full/0/default.jpg"/>
               <lb/>
               <placeName corresp="#淡路国"> 淡路 </placeName> 塩二升、東鰒七斤五両、薄鰒六斤十両、堅魚五斤、干鯛六隻、干鯵卅隻、鮨鰒・煮塩年魚・ <anchor
                 xml:id="app3920060101"/> 醤鮒 <anchor xml:id="app3920060101e"/>
@@ -1602,7 +1602,7 @@
               米二斗、糯米二斗、糯・粟 <anchor xml:id="app3920080101"/> 子 <anchor xml:id="app3920080101e"/>
               等糒各二升、糯稲十束、小麦四升、大豆二升二合、小豆一升六合、胡麻子二升八合、荏子三升、清酒・濁酒各一斗、酢・醤各五升、塩二升、東鰒一斤十両二分四銖、薄鰒十三斤五両一分二銖、 <placeName
                 corresp="#隠伎国"> 隠伎 </placeName> 鰒二斤五両一分二銖、煮堅魚・螺各十三両一分二銖、烏賊十両二分四銖、腊五升、紫菜十両二分四銖、海松・海藻各 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00007.tif/full/full/0/default.jpg"/>
               六斤十両二分四銖、干薑三両、干羊蹄一籠、干 <anchor xml:id="app3920080102"/> 棗 <anchor xml:id="app3920080102e"/>
               二升、搗栗子六升、干栗子二升、生栗子二斗二升八合、干柿子二連、椎子四升、菱子・蓮子各二升、 <anchor xml:id="app3920080103"/> 橘子廿四蔭 <anchor
                 xml:id="app3920080103e"/> 、桙橘子十 <anchor xml:id="app3920080104"/> 枝 <anchor xml:id="app3920080104e"/>
@@ -1643,7 +1643,7 @@
                 xml:id="app3920090102"/> 棗 <anchor xml:id="app3920090102e"/> ・干栗子各二升、搗栗子四升、生栗子一斗、干柿子二連、椎子・菱子各四升、橘子四蔭、 <anchor
                 xml:id="app3920090103"/> 桙橘子 <anchor xml:id="app3920090103e"/>
               十枝、明櫃十合、陶大盤十九口、麻笥盤十二口、鉢廿六口、大瓶七口、筥瓶六口、酢瓶十口、洗盤十二口、燼瓫・臼各八口、土熬堝卅口、大洗盤・小洗盤各四口、大盤八口、火蓋十二口、瓫十口、松明八束、炭四石、薪六百斤、供奉官人二人・膳部六人各給衫・襅、
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00008.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00008.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"> 右、豊楽料、 </seg>
             </p>
@@ -1726,7 +1726,7 @@
               諸節供御料、〈中宮亦同、下皆准此、〉 <lb/> 正月三節 <lb/> 米三斗、糯米四斗六升五合、糯稲十五束、 <anchor xml:id="app3920130101"/> 糯糒 <anchor
                 xml:id="app3920130101e"/> 三升、粟 <anchor xml:id="app3920130102"/> 子 <anchor xml:id="app3920130102e"/>
               糒六升、小麦一斗二升、荏子九升、胡麻子八升四合、大豆三 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00009.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00009.tif/full/full/0/default.jpg"/>
               升三合、小豆二升四合、清酒・濁酒・酢・油各一斗五升、醤三斗、塩六升、東鰒八斤四両、 <placeName corresp="#隠伎国"> 隠伎 </placeName>
               鰒十一斤一両、煮堅魚四斤二両、螺四斤三両、紫菜一斤、干薑一斤、干棗子三升、搗栗子九升、生栗子六斗四升二合、干柿子六連、椎子六升、菱子三升、橘子卅六蔭、桙橘子十五枝、掇橘子一斗、長櫃五合、熬堝十八口、竹三囲、料理所炭十二石、薪一千八百斤、供奉膳部卌人〈卅人御、十人中宮、〉各給紺布衫一領、〈通用三節、〉其下番膳部卅人、節別各限二箇日給食、人別日飯二升、〈余節准此、〉 <lb/>
               <seg rendition="#indent"> 右、三節料、依前件一度請受、節別分供、但射礼料用此内、又十八日賭射、弁備肴物給王卿及 <orgName corresp="#近衛府"> 近衛 </orgName>
@@ -1799,7 +1799,7 @@
             <head ana="五月五日"/>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39201601 engishiki_v39_en.xml#item39201601" xml:id="item39201601">
               五月五日節 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00010.tif/full/full/0/default.jpg"/>
               <lb/> 米一斗三升、糯米一斗七升、糯稲五束、〈焼米料、〉糯・粟糒各二升、大豆二升、小麦四升、胡麻子・荏子各四升、酒一斗、酢・油各五升、醤一斗、塩二升、鳥腊四斤、東鰒一斤十両、 <placeName
                 corresp="#長門国"> 長門 </placeName> 鰒・ <placeName corresp="#阿波国"> 阿波 </placeName> 鰒・ <placeName corresp="#出雲国">
                 出雲 </placeName> 鰒・ <placeName corresp="#隠伎国"> 隠伎 </placeName>
@@ -1860,7 +1860,7 @@
               <note> 堅　九本「塩」。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00011.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00011.tif/full/full/0/default.jpg"/>
           <div ana="内膳" corresp="engishiki_v39_ja.xml#article392019 engishiki_v39_en.xml#article392019" n="39-2.19" type="条"
             xml:id="article392019">
             <head ana="供御月料"/>
@@ -1938,7 +1938,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39201903 engishiki_v39_en.xml#item39201903" xml:id="item39201903">
               芥子・豉各四升五合、醤 <anchor xml:id="app3920190301"/> 瓜 <anchor xml:id="app3920190301e"/> 廿三顆、干棗子一斗四升二合五夕、搗 <anchor
                 xml:id="app3920190302"/> 栗 <anchor xml:id="app3920190302e"/> 二斗九升三合五夕、干栗子七斗五升、生栗子二石二斗五升、干 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00012.tif/full/full/0/default.jpg"/>
               柿子廿九連、椎子四斗五升、呉桃子一斗五升、橘子卌五蔭、掇橘子・菱子各二斗二升五合、蓮子一斗五升七合五夕、 </p>
             <app from="#app3920190301" to="#app3920190301e">
               <lem wit="#九本"> 瓜 </lem>
@@ -2002,7 +2002,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39202301 engishiki_v39_en.xml#item39202301" xml:id="item39202301">
               年料 <lb/> 御飯帛被三領、〈二領別綿五屯、一領三屯一両二銖、並長二丈五尺、〉裹 <anchor xml:id="app3920230101"/> 衦 <anchor xml:id="app3920230101e"/>
               麺帛帷一条、〈長七尺、〉絹大篩四口、〈水瓶麻笥料、口別各長三尺五寸、〉絹小篩九十五口、〈煮雑羹所十三口、漬菜所十四口、菓餅 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00013.tif/full/full/0/default.jpg"/>
               所十三口、麦粉所 <anchor xml:id="app3920230102"/> 十 <anchor xml:id="app3920230102e"/> 口、糯粉所七口、油所三口、 <anchor
                 xml:id="app3920230103"/> 甘 <anchor xml:id="app3920230103e"/>
               葛煎所三口、醤所八口、雑用廿四口、並長二尺、〉薄絁篩廿五口、〈搗胡麻子料四口、各長四尺、胡桃料三口、各長二尺、甘葛煎料二口、各長二尺五寸、漉蓼料五口、各長四尺、芥子料三口、各長三尺、已上十七口、並二重、醤料八口、各長二尺、〉外居案十二脚、帊料油絁十二条、〈各長五尺一寸、広一
@@ -2166,7 +2166,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39202307 engishiki_v39_en.xml#item39202307" xml:id="item39202307">
               席十六枚、〈四枚張大炊殿上料、四枚暴涼雑菜料、四枚 <anchor xml:id="app3920230701"/> 帊 <anchor xml:id="app3920230701e"/>
               御案料、四枚舂塩并楡料、〉薦十六枚、〈八枚張大炊殿上料、八枚翳御膳所料、〉黒葛六斤、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00014.tif/full/full/0/default.jpg"/>
               〈結大炊殿上張席料、〉 </p>
             <app from="#app3920230701" to="#app3920230701e">
               <lem wit="#九本"> 帊 </lem>
@@ -2311,7 +2311,7 @@
             <head ana="供御料雑器"/>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39202401 engishiki_v39_en.xml#item39202401" xml:id="item39202401">
               供御料雑器 <lb/> 朱漆台盤四面、〈二面尋常料、二面節会料、〉 <lb/> 黒漆台盤二面、〈潔斎料、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00015.tif/full/full/0/default.jpg"/>
               <lb/> 金・銀・朱漆・瓷雑器、 <lb/>
               <seg rendition="#indent"> 右、供御雑器従蔵人所請、但尋常料台盤二面帊料油絁二丈五尺二寸、随破損申請、受 <orgName corresp="#内蔵寮"> 内蔵寮 </orgName> 、
               </seg>
@@ -2384,7 +2384,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39202701 engishiki_v39_en.xml#item39202701" xml:id="item39202701">
               造粉熟料 <lb/>
               白米四石、大角豆一石八斗、漉粉薄絹袋・水篩各二口、〈袋各長六尺、篩各一尺五寸、〉干粉暴布帳一条、〈長三丈、〉帊水瓶暴布一条、〈長四尺、〉挙粉暴布袋二口、〈各長六尺、〉水瓶麻笥一口、酒槽一隻、由加二口、杓一柄、席二枚、簀二枚、薪日別卅斤、
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00016.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00016.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"> 右、起三月一日尽八月卅日供之、 </seg>
             </p>
@@ -2449,7 +2449,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39203001 engishiki_v39_en.xml#item39203001" xml:id="item39203001">
               五月五日、山科園進早瓜一捧、〈若不実者、献花根、〉 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00017.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00017.tif/full/full/0/default.jpg"/>
           <div ana="内膳" corresp="engishiki_v39_ja.xml#article392031 engishiki_v39_en.xml#article392031" n="39-2.31" type="条"
             xml:id="article392031">
             <head ana="年料雑菜"/>
@@ -2548,7 +2548,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39203403 engishiki_v39_en.xml#item39203403" xml:id="item39203403">
               茄子五石、〈料塩三斗、〉醤茄子六斗、〈料塩一斗二升、汁糟・ <anchor xml:id="app3920340301"/> 未 <anchor xml:id="app3920340301e"/>
               醤・滓醤各一斗八升、〉糟茄子六斗、〈料塩一斗二升・汁糟一斗八升、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00018.tif/full/full/0/default.jpg"/>
               竜葵葅六斗、〈料塩六升・ <anchor xml:id="app3920340302"/> 楡 <anchor xml:id="app3920340302e"/>
               二升四合、〉竜葵子漬三斗、〈料塩九升、〉水䓗十石、〈料塩七升、〉糟漬小水䓗一石、〈料塩一斗二升・汁糟五斗、〉蘭葅三斗、〈料塩二升四合・ <anchor xml:id="app3920340303"/> 楡 <anchor
                 xml:id="app3920340303e"/> 一升二合、〉大豆六斗、〈料塩六升・汁糟一斗八升、〉山蘭二斗、〈料塩四升、〉蓼葅四斗、〈料塩四升・ <anchor xml:id="app3920340304"/> 楡
@@ -2667,7 +2667,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39203801 engishiki_v39_en.xml#item39203801" xml:id="item39203801">
               造雑魚鮨十石・味塩魚六斗〈 <placeName corresp="#河内国"> 河内国 </placeName> 江厨所進、〉料、 <anchor xml:id="app3920380101"/> 商 <anchor
                 xml:id="app3920380101e"/> 布十六段、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00019.tif/full/full/0/default.jpg"/>
               信濃麻百斤、白米一石、塩一石三斗、 </p>
             <app from="#app3920380101" to="#app3920380101e">
               <lem cause="意補"> 商 </lem>
@@ -2745,7 +2745,7 @@
                 <anchor xml:id="app3920400201"/> 新 <anchor xml:id="app3920400201e"/> 嘗会二節各八担、正月七日・十六日・五月五日・七月七日・九月九日五節各三担、〉
                 <placeName corresp="#参河国"> 参河国 </placeName> 、〈正月三節各三担、〉 <placeName corresp="#若狭国"> 若狭国 </placeName> 、〈三節各十担、〉
                 <placeName corresp="#紀伊国"> 紀伊 </placeName> ・ <placeName corresp="#淡路国"> 淡路 </placeName> 両国、〈三節各五担、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00020.tif/full/full/0/default.jpg"/>
               <lb/> 右、 <placeName corresp="#参河国"> 参河国 </placeName> 進雉、余国雑鮮味物、但 <placeName corresp="#近江国"> 近江国 </placeName>
               元日副進猪・鹿、其旬料已下並 <anchor xml:id="app3920400202"/> 収 <anchor xml:id="app3920400202e"/>
               <orgName corresp="#内膳司"> 司 </orgName> 家、随事供之、 </p>
@@ -2958,7 +2958,7 @@
                 ><placeName corresp="#播磨国"> 播磨国 </placeName> 、〈鮨年魚二担四壺、〉 <placeName corresp="#美作国"> 美作国 </placeName> 、〈鮨鮎、〉
                 <placeName corresp="#備前国"> 備前国 </placeName> 、〈水 <anchor xml:id="app3920420601"/> 母 <anchor
                 xml:id="app3920420601e"/> 十缶二度、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00021.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00021.tif/full/full/0/default.jpg"/>
               <placeName corresp="#備中国"> 備中国 </placeName> 、〈煮塩年魚八缶、〉 <placeName corresp="#長門国"> 長門国 </placeName> 、〈穉海藻一百四籠、〉 </p>
             <app from="#app3920420601" to="#app3920420601e">
               <lem wit="#九本"> 母 </lem>
@@ -3094,7 +3094,7 @@
             <head ana="木器土器"/>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39205001 engishiki_v39_en.xml#item39205001" xml:id="item39205001">
               作木器二人、〈一人贄殿、一人 <orgName corresp="#内膳司"> 司 </orgName> 家、〉作土器九 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00022.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00022.tif/full/full/0/default.jpg"/>
               人、月別一人所造、折櫃卅合、土器七百八十口、〈大坏・中坏・窪坏・平坏・埦形・片盤・瓫・堝等類、〉作土器人充商布九段〈埴器料、〉・鍬九口、〈納旧請新、〉粮人別日黒米二升・塩二夕、時服夏各絁四丈五尺、冬絁一疋三丈・綿四屯、
             </p>
           </div>
@@ -3165,7 +3165,7 @@
               <note> 使　土本等「仕」。九本により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00023.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00023.tif/full/full/0/default.jpg"/>
           <div ana="内膳" corresp="engishiki_v39_ja.xml#article392059 engishiki_v39_en.xml#article392059" n="39-2.59" type="条"
             xml:id="article392059">
             <head ana="川船"/>
@@ -3228,7 +3228,7 @@
             </app>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39206304 engishiki_v39_en.xml#item39206304" xml:id="item39206304">
               営大角豆一段、種子八升、惣単功十三人、耕地一遍、把犂一人、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00024.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00024.tif/full/full/0/default.jpg"/>
               馭牛一人、牛 <anchor xml:id="app3920630401"/> 一頭 <anchor xml:id="app3920630401e"/> 、料理一人、畦上作二人、殖功二人、芸一遍三人、採功三人、 </p>
             <app from="#app3920630401" to="#app3920630401e">
               <lem wit="#九本"> 一頭 </lem>
@@ -3264,7 +3264,7 @@
             </app>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39206309 engishiki_v39_en.xml#item39206309" xml:id="item39206309">
               営薑一段、種子四石、惣単功七十八人、耕地五遍、把犂二人半、馭牛二人半、牛二頭半、料理平和二人、糞二百十担、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00025.tif/full/full/0/default.jpg"/>
               運功卅五人、分畦四人、殖功四人、〈四月、〉芸三遍、第一遍九人、第二遍七人、第三遍六人、採択功六人、 </p>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39206310 engishiki_v39_en.xml#item39206310" xml:id="item39206310">
               営蕗一段、種子二石、惣単功卅四人、耕地二遍、把犂一人、馭牛一人、牛一頭、料理平和二人、糞百廿担、運功廿人、殖功二人、〈九月、〉芸二遍、第一遍二人、〈三月、〉第二遍二人、〈六月、〉刈功四人、三年一殖、 </p>
@@ -3287,7 +3287,7 @@
             <p ana="項" corresp="engishiki_v39_ja.xml#item39206313 engishiki_v39_en.xml#item39206313" xml:id="item39206313">
               営晩瓜一段、種子四合五夕、惣単功卅五人半、 <anchor xml:id="app3920631301"/> 耕 <anchor xml:id="app3920631301e"/>
               地二遍、把犂一人、馭牛一人、牛一頭、料理平和三人、掘畦溝三人、位三百六十座、踏位一人、下子半人、壅一人、〈三度、〉芸三遍、第一 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00026.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00026.tif/full/full/0/default.jpg"/>
               遍十人、〈三月、〉第二遍八人、〈四月、〉第三遍七人、〈五月、〉 </p>
             <app from="#app3920631301" to="#app3920631301e">
               <lem wit="#土本 #九本 #近本 #壬本 #慶長本 #梵本"> 耕 </lem>
@@ -3318,7 +3318,7 @@
               営胡䕑一段、種子二斗五升、惣単功廿八人、耕地二遍、把犂一人、馭牛一人、牛一頭、料理平和二人、畦上作二人、糞百卅二担、運功廿二人、下子半人、〈三月、八月、〉 </p>
             <p ana="項" corresp="engishiki_v39_ja.xml#item39206319 engishiki_v39_en.xml#item39206319" xml:id="item39206319"> 営
                 <anchor xml:id="app3920631901"/> 蕓薹 <anchor xml:id="app3920631901e"/> 一段、種子一升、惣単功廿八人、耕地二遍、把犂一人、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00027.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00027.tif/full/full/0/default.jpg"/>
               馭牛一人、牛一頭、料理平和二人、畦上作二人、糞百卅二担、運功廿二人、下子半人、〈三月、八月、〉 </p>
             <app from="#app3920631901" to="#app3920631901e">
               <lem wit="#土本 #九本 #近本 #壬本 #慶長本 #梵本"> 蕓薹 </lem>
@@ -3373,94 +3373,94 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-39/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-39">
     <!--  巻39-2内膳とまったく同じなので、後ほど統合 -->
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5068" xml:id="page5068">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5069" xml:id="page5069">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5070" xml:id="page5070">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5071" xml:id="page5071">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5072" xml:id="page5072">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5073" xml:id="page5073">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5074" xml:id="page5074">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5075" xml:id="page5075">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5076" xml:id="page5076">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5077" xml:id="page5077">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5078" xml:id="page5078">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5079" xml:id="page5079">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5080" xml:id="page5080">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5081" xml:id="page5081">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5082" xml:id="page5082">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5083" xml:id="page5083">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5084" xml:id="page5084">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5085" xml:id="page5085">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5086" xml:id="page5086">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5087" xml:id="page5087">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5088" xml:id="page5088">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5089" xml:id="page5089">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5090" xml:id="page5090">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5091" xml:id="page5091">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5092" xml:id="page5092">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5093" xml:id="page5093">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5094" xml:id="page5094">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5095" xml:id="page5095">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39/page5096" xml:id="page5096">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-39%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-39/00029.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v41.xml
+++ b/TEI編集用/engishiki_v41.xml
@@ -1336,7 +1336,7 @@
   <text>
     <body>
       <div ana="弾正" n="41" type="巻" xml:id="volume41">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai41">
           <p xml:id="shudai4101"> 延喜式巻第卌一 </p>
         </div>
@@ -1366,7 +1366,7 @@
             <p ana="項" corresp="engishiki_v41_ja.xml#item41100301 engishiki_v41_en.xml#item41100301" xml:id="item41100301"> 凡
                 <orgName corresp="#弾正台"> 弾正 </orgName> 不得弾太政大臣、太政大臣得弾 <orgName corresp="#弾正台"> 弾正 </orgName> 、其左右大臣与 <orgName
                 corresp="#弾正台"> 弾正 </orgName> 、若有非違者、各得 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00003.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00003.tif/full/full/0/default.jpg"/>
               互弾、 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411004 engishiki_v41_en.xml#article411004" n="41.4" type="条"
@@ -1411,7 +1411,7 @@
             <p ana="項" corresp="engishiki_v41_ja.xml#item41100901 engishiki_v41_en.xml#item41100901" xml:id="item41100901"> 凡
                 <orgName corresp="#弾正台"> 台 </orgName> 奏弾事者、不経 <orgName corresp="#太政官"> 太政官 </orgName>
               而直奏聞、〈将奏事者、忠詣閤門、告大舎人令伺奏事状、有可召者、尹已下忠已上共入上聞、若御大極殿者、忠就大舎人処伺奏事状、舎人召 <orgName corresp="#弾正台"> 台 </orgName> 者、准前上聞、
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00005.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00005.tif/full/full/0/default.jpg"
               /> 但臨時奏事者、忠以上一人詣内侍所、令内侍奏聞之、〉 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411010 engishiki_v41_en.xml#article411010" n="41.10" type="条"
@@ -1482,7 +1482,7 @@
             <head ana="諸堂官人道"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41101801 engishiki_v41_en.xml#item41101801" xml:id="item41101801">
               凡含嘉堂并顕章堂官人、不得従暉章堂・ <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00006.tif/full/full/0/default.jpg"/>
               修式堂後通東門、承光堂官人、不得通 <anchor xml:id="app4110180101"/> 西 <anchor xml:id="app4110180101e"/> 門、 </p>
             <app from="#app4110180101" to="#app4110180101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #梵本"> 西 </lem>
@@ -1549,7 +1549,7 @@
                 > 太政官 </orgName> 外記拝少納言、左右史拝弁、 <orgName corresp="#省"> 省 </orgName> ・ <orgName corresp="#弾正台"> 台 </orgName> ・
                 <orgName corresp="#職"> 職 </orgName> ・ <orgName corresp="#春宮坊"> 坊 </orgName> ・使・ <orgName corresp="#寮"> 寮
               </orgName> ・ <orgName corresp="#司"> 司 </orgName> 判 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00007.tif/full/full/0/default.jpg"/>
               官・主典、諸 <orgName corresp="#衛府"> 衛府 </orgName> 監・曹・尉・志、 <orgName corresp="#大宰府"> 大宰 </orgName>
                 監・典拝次官已上、助教・直講拝博士、<orgName corresp="#春宮坊"
               >東宮</orgName>官拝傅、六位已下拝学士、国介拝守、鎮守監・曹拝将軍、官人見本国守、官卑者致敬、位同者不拝、若就国見猶拝、〈諸司・ <placeName corresp="#諸国"> 諸国 </placeName>
@@ -1590,7 +1590,7 @@
             <head ana="元正"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41103001 engishiki_v41_en.xml#item41103001" xml:id="item41103001">
               凡元正之日、糺弾五位以上諸王・諸臣威儀、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00008.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00008.tif/full/full/0/default.jpg"/>
               并着用物色違制、及朝拝刀祢等非違、〈諸節准此、〉 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411031 engishiki_v41_en.xml#article411031" n="41.31" type="条"
@@ -1657,7 +1657,7 @@
             <p ana="項" corresp="engishiki_v41_ja.xml#item41104001 engishiki_v41_en.xml#item41104001" xml:id="item41104001"> 凡
                 <orgName corresp="#弾正台"> 台 </orgName> 疏以上、自非別勅、不得権任他務、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00009.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00009.tif/full/full/0/default.jpg"/>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411041 engishiki_v41_en.xml#article411041" n="41.41" type="条"
             xml:id="article411041">
             <head ana="召式部省"/>
@@ -1746,7 +1746,7 @@
             <p ana="項" corresp="engishiki_v41_ja.xml#item41105201 engishiki_v41_en.xml#item41105201" xml:id="item41105201">
               凡除礼服并参議已上半臂、五位已上幞頭之外、不得着羅、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00010.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00010.tif/full/full/0/default.jpg"/>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411053 engishiki_v41_en.xml#article411053" n="41.53" type="条"
             xml:id="article411053">
             <head ana="衣服色"/>
@@ -1868,7 +1868,7 @@
             <head ana="衛府舎人刀緒"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41106501 engishiki_v41_en.xml#item41106501" xml:id="item41106501"> 凡
                 <orgName corresp="#衛府"> 衛府 </orgName> 舎人刀緒、左近衛緋絁、右近衛緋纈、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00011.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00011.tif/full/full/0/default.jpg"/>
               左兵衛深緑、右兵衛深緑纈、左門部浅 <anchor xml:id="app4110650101"/> 縹 <anchor xml:id="app4110650101e"/> 、右門部浅縹纈、 </p>
             <app from="#app4110650101" to="#app4110650101e">
               <lem wit="#近本 #壬本 #京博本 #梵本"> 縹 </lem>
@@ -1928,7 +1928,7 @@
             <head ana="染袴"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41107301 engishiki_v41_en.xml#item41107301" xml:id="item41107301">
               凡親王以下五位以上、及内親王・孫王・女御・内命婦、并参議以上、非参議三位嫡妻・女子、大 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00012.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00012.tif/full/full/0/default.jpg"/>
               臣孫・女蔵人等従、並聴着染袴、 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411074 engishiki_v41_en.xml#article411074" n="41.74" type="条"
@@ -2009,7 +2009,7 @@
             <head ana="烏犀帯"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41108401 engishiki_v41_en.xml#item41108401" xml:id="item41108401">
               凡烏犀帯聴六位以下着用、但有通天文 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00013.tif/full/full/0/default.jpg"/>
               者、不在聴限、 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411085 engishiki_v41_en.xml#article411085" n="41.85" type="条"
@@ -2065,7 +2065,7 @@
             <head ana="車屋形裏"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41109301 engishiki_v41_en.xml#item41109301" xml:id="item41109301"> 凡
                 <anchor xml:id="app4110930101"/> 市 <anchor xml:id="app4110930101e"/> 人、不得以白綾夾纈等為車屋形裏、以雑楷色為従者衣、以綵色編竹成文為簾、及 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00014.tif/full/full/0/default.jpg"/>
               将従四人以上、 </p>
             <app from="#app4110930101" to="#app4110930101e">
               <lem wit="#土本 #近本 #壬本 #京博本 #梵本"> 市 </lem>
@@ -2101,7 +2101,7 @@
             <head ana="禁断青刈"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41109601 engishiki_v41_en.xml#item41109601" xml:id="item41109601">
               凡禁断刈大小麦青苗、為馬草売買、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00015.tif/full/full/0/default.jpg"/>
               并桑・棗木鞍橋、 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411097 engishiki_v41_en.xml#article411097" n="41.97" type="条"
@@ -2173,7 +2173,7 @@
             <p ana="項" corresp="engishiki_v41_ja.xml#item41110501 engishiki_v41_en.xml#item41110501" xml:id="item41110501">
               凡進告朔函時者、弁官・ <orgName corresp="#式部省"> 式部 </orgName> ・ <orgName corresp="#兵部省"> 兵部 </orgName> ・ <orgName
                 corresp="#弾正台"> 弾正 </orgName> 五位已上者、立本司庁前、他司五位已上者、立東西庁前、諸六位已下、立弁官・ <orgName corresp="#式部省"> 式 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00016.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00016.tif/full/full/0/default.jpg"/>
                 部 </orgName> 庁後、 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411106 engishiki_v41_en.xml#article411106" n="41.106" type="条"
@@ -2231,7 +2231,7 @@
             <p ana="項" corresp="engishiki_v41_ja.xml#item41111001 engishiki_v41_en.xml#item41111001" xml:id="item41111001">
               凡神泉苑廻地十町内、令 <orgName corresp="#京職"> 京職 </orgName> 栽柳、〈町別七株、〉 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00017.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00017.tif/full/full/0/default.jpg"/>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411111 engishiki_v41_en.xml#article411111" n="41.111" type="条"
             xml:id="article411111">
             <head ana="神泉大学廻地"/>
@@ -2282,7 +2282,7 @@
               凡喚 <orgName corresp="#京職"> 左右京職 </orgName> 云、将遣忠以下検京中非違・道橋及諸寺、宜厳仰条令、預定便処会集男女、亦告諸寺三綱等、令弁備如上、即忠以下到彼会所問云、有
                 <orgName corresp="#京職"><anchor xml:id="app4111170101"/> 京職 <anchor xml:id="app4111170101e"/>
               </orgName> 官人及坊令等、冤枉百姓、凌侮長幼耶、又有孝子・順孫・義父・節婦以不、又有悪女・擾乱・閭巷以不、又到寺家遣条令告三綱、即撃鐘会僧、訖条令申云、坐定、即 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00018.tif/full/full/0/default.jpg"/>
               忠以下入着座、問衆僧云、三綱供養衆僧有所闕失耶、又有罵辱衆僧、并将三宝物餉送官人耶、又有三宝燃燈所闕失耶、次問三綱云、有衆僧乖違法式、擾乱徒衆、及罵詈三綱、凌突長宿、好小道卜吉凶、懐巫術救疾病者耶、又有飲酒酔乱、及与人闘乱者耶、又有着禁色者耶、〈謂綾・羅・錦・綺之類、〉 </p>
             <app from="#app4111170101" to="#app4111170101e">
               <lem wit="#慶安版本 #明暦版本 #寛文版本 #享保版本 #雲本"> 京職 </lem>
@@ -2336,7 +2336,7 @@
             <head ana="隊仗"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41112401 engishiki_v41_en.xml#item41112401" xml:id="item41112401">
               凡隊仗内有非違、而 <orgName corresp="#弾正台"> 台 </orgName> 不弁姓名者、直至仗 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00019.tif/full/full/0/default.jpg"/>
               頭、就主司問之、 </p>
           </div>
           <div ana=" 弾正" corresp="engishiki_v41_ja.xml#article411125 engishiki_v41_en.xml#article411125" n="41.125" type="条"
@@ -2406,7 +2406,7 @@
               <note> 才伎　土本・近本「伎才」。壬本・京博本「伎少」、京博本は「少」に朱傍書「才歟」。訳注本に従い意改する。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00020.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00020.tif/full/full/0/default.jpg"/>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411134 engishiki_v41_en.xml#article411134" n="41.134" type="条"
             xml:id="article411134">
             <head ana="蕃客朝拝"/>
@@ -2472,7 +2472,7 @@
             <p ana="項" corresp="engishiki_v41_ja.xml#item41114201 engishiki_v41_en.xml#item41114201" xml:id="item41114201">
               凡運 <orgName corresp="#民部省"> 民部 </orgName> 廩院米車馬、自美福門脇門、運 <orgName corresp="#大膳職"> 大膳職 </orgName> 雑物・ <orgName
                 corresp="#大炊寮"> 大炊寮 </orgName> 米并雑穀、自郁芳門、運在中院西 <orgName corresp="#木工寮"> 木工 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00021.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00021.tif/full/full/0/default.jpg"/>
                 寮 </orgName> 木屋材瓦・ <orgName corresp="#造酒司"> 造酒司 </orgName> 米、自談天門、運 <orgName corresp="#春宮坊"> 春宮坊 </orgName>
               雑物、自待賢門、並聴出入、 </p>
           </div>
@@ -2571,7 +2571,7 @@
             <head ana="出棄病人"/>
             <p ana="項" corresp="engishiki_v41_ja.xml#item41115301 engishiki_v41_en.xml#item41115301" xml:id="item41115301">
               凡部内百姓出棄病人者、五位以上取名奏聞、六位 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00022.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00022.tif/full/full/0/default.jpg"/>
               以下不論蔭贖決杖一百、其 <orgName corresp="#京職"> 職 </orgName> 司知而不糺、及条令・坊長・隣保相隠不告、並与同罪、 </p>
           </div>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411154 engishiki_v41_en.xml#article411154" n="41.154" type="条"
@@ -2618,7 +2618,7 @@
               <note> 典　土本・近本・壬本・京博本・梵本「曲」。版本に従い意改する。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00023.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00023.tif/full/full/0/default.jpg"/>
           <div ana="弾正" corresp="engishiki_v41_ja.xml#article411159 engishiki_v41_en.xml#article411159" n="41.159" type="条"
             xml:id="article411159">
             <head ana="男入尼寺"/>
@@ -2648,78 +2648,78 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-41/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-41">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5126" xml:id="page5126">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5127" xml:id="page5127">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5128" xml:id="page5128">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5129" xml:id="page5129">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5130" xml:id="page5130">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5131" xml:id="page5131">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5132" xml:id="page5132">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5133" xml:id="page5133">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5134" xml:id="page5134">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5135" xml:id="page5135">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5136" xml:id="page5136">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5137" xml:id="page5137">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5138" xml:id="page5138">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5139" xml:id="page5139">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5140" xml:id="page5140">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5141" xml:id="page5141">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5142" xml:id="page5142">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5143" xml:id="page5143">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5144" xml:id="page5144">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5145" xml:id="page5145">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5146" xml:id="page5146">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5147" xml:id="page5147">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5148" xml:id="page5148">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41/page5149" xml:id="page5149">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-41%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-41/00024.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v42.xml
+++ b/TEI編集用/engishiki_v42.xml
@@ -1365,7 +1365,7 @@
   <text>
     <body>
       <div ana="左右京・東西市" n="42" type="巻" xml:id="volume42">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai42">
           <p xml:id="shudai4201"> 延喜式巻第卌二〈 <orgName corresp="#京職"> 左右京 </orgName> ・ <orgName corresp="#市司"> 東西市 </orgName> 〉
           </p>
@@ -1448,7 +1448,7 @@
               <note> 凡…等　九本は本条無し。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00003.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00003.tif/full/full/0/default.jpg"/>
           <div ana="左右京" corresp="engishiki_v42-1_en.xml#article421004 engishiki_v42-1_ja.xml#article421004" n="42-1.4"
             type="条" xml:id="article421004">
             <head ana="大嘗大祓"/>
@@ -1547,7 +1547,7 @@
             <head ana="射礼"/>
             <p ana="項" corresp="engishiki_v42-1_en.xml#item42100901 engishiki_v42-1_ja.xml#item42100901"
               xml:id="item42100901"><anchor xml:id="app4210090101"/> 凡 <anchor xml:id="app4210090101e"/> 正月十七日、於豊楽院有射礼節、自豊
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00004.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00004.tif/full/full/0/default.jpg"
               /> 楽門迄儀鸞門、 <orgName corresp="#京職"> 左右京職 </orgName> 中分其庭東西掃除、其夫功食料 <anchor xml:id="app4210090102"/> 充 <anchor
                 xml:id="app4210090102e"/> 調徭銭、 </p>
             <app from="#app4210090101" to="#app4210090101e">
@@ -1673,7 +1673,7 @@
             <head ana="宮城辺立鋪"/>
             <p ana="項" corresp="engishiki_v42-1_en.xml#item42101501 engishiki_v42-1_ja.xml#item42101501"
               xml:id="item42101501"><anchor xml:id="app4210150101"/> 凡 <anchor xml:id="app4210150101e"/> 宮城辺、量便立鋪、兵士廿人為番守衛、其
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00005.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00005.tif/full/full/0/default.jpg"
               /> 功食、以徭銭 <anchor xml:id="app4210150102"/> 充 <anchor xml:id="app4210150102e"/> 、 </p>
             <app from="#app4210150101" to="#app4210150101e">
               <note> 凡…充　九本は本条無し。 </note>
@@ -1827,7 +1827,7 @@
               <note> 凡…利　九本は本条無し。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00006.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00006.tif/full/full/0/default.jpg"/>
           <div ana="左右京" corresp="engishiki_v42-1_en.xml#article421025 engishiki_v42-1_ja.xml#article421025" n="42-1.25"
             type="条" xml:id="article421025">
             <head ana="路辺病者"/>
@@ -1955,7 +1955,7 @@
             <p ana="項" corresp="engishiki_v42-1_en.xml#item42103301 engishiki_v42-1_ja.xml#item42103301"
               xml:id="item42103301"><anchor xml:id="app4210330101"/> 書生 <anchor xml:id="app4210330101e"/>
               卅四人〈十一人長上、廿三人雇、限勘造計帳月、〉 <lb/> 坊長卅五人〈条別四人、但一・二条各三人、北辺坊一人、〉 <lb/> 兵士卌人、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00007.tif/full/full/0/default.jpg"/>
               <lb/> 守正倉六人、 <lb/> 守客館二人〈只置 <orgName corresp="#京職"> 右京 </orgName> 、 <orgName corresp="#京職"> 左京 </orgName> 不須、〉
               <lb/> 守朱雀樹四人、 <lb/> 掃清丁卅六人〈条別四人、但一・二条各三人、北辺坊二人、〉 <lb/>
               <orgName corresp="#市司"> 市司 </orgName> 執鎰二人、 </p>
@@ -2018,7 +2018,7 @@
               xml:id="item42103603">
               <seg rendition="#indent"> 右、依前 <anchor xml:id="app4210360301"/> 件 <anchor xml:id="app4210360301e"/>
                 、経国之間供給、准国司巡行法、充用職 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00008.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00008.tif/full/full/0/default.jpg"/>
                 写田直、其紙・筆等、以徭銭 <anchor xml:id="app4210360302"/> 充 <anchor xml:id="app4210360302e"/> 、 </seg>
             </p>
             <app from="#app4210360301" to="#app4210360301e">
@@ -2124,7 +2124,7 @@
             <head ana="誤置職写"/>
             <p ana="項" corresp="engishiki_v42-1_en.xml#item42104101 engishiki_v42-1_ja.xml#item42104101"
               xml:id="item42104101"><anchor xml:id="app4210410101"/> 凡 <anchor xml:id="app4210410101e"/> 進計帳戸、誤置職写者、進帳之後、六十日内
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00009.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00009.tif/full/full/0/default.jpg"
               /> 一度覚挙、若過此程、令計帳所官人以下備償其直、余官不 <anchor xml:id="app4210410102"/> 預 <anchor xml:id="app4210410102e"/> 、 </p>
             <app from="#app4210410101" to="#app4210410101e">
               <note> 凡…預　九本は本条無し。 </note>
@@ -2246,7 +2246,7 @@
               <note> 凡…之　九本は本条無し。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00010.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00010.tif/full/full/0/default.jpg"/>
           <div ana="左右京" corresp="engishiki_v42-1_en.xml#article421051 engishiki_v42-1_ja.xml#article421051" n="42-1.51"
             type="条" xml:id="article421051">
             <head ana="京戸課徭"/>
@@ -2383,7 +2383,7 @@
               </seg>
               <lb/>
               <seg rendition="#indent"><anchor xml:id="app4210580206"/> 路広十丈 <anchor xml:id="app4210580206e"/> 、 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00011.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00011.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"> 小路廿六、広各四丈、 </seg>
               <lb/>
@@ -2521,7 +2521,7 @@
                   xml:id="app4210580503"/> 各 <anchor xml:id="app4210580503e"/> 八尺〈垣基三尺、犬行五尺、〉 </seg>
               <lb/>
               <seg rendition="#indent"><anchor xml:id="app4210580504"/> 溝 <anchor xml:id="app4210580504e"/> 広各四尺、 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00012.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00012.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"><anchor xml:id="app4210580505"/> 両 <anchor xml:id="app4210580505e"/> 溝間、七丈六尺、 </seg>
             </p>
@@ -2745,7 +2745,7 @@
               <seg rendition="#indent"><anchor xml:id="app4210581004"/> 南垣半三尺 <anchor xml:id="app4210581004e"/> 、 </seg>
               <lb/>
               <seg rendition="#indent"><anchor xml:id="app4210581005"/> 犬行五尺 <anchor xml:id="app4210581005e"/> 、 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00013.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00013.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"><anchor xml:id="app4210581006"/> 溝広四尺 <anchor xml:id="app4210581006e"/> 、 </seg>
               <lb/>
@@ -2946,7 +2946,7 @@
               <note> 凡…罰之、　九本は本条無し。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00014.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00014.tif/full/full/0/default.jpg"/>
           <div ana="東西市" corresp="engishiki_v42-2_en.xml#article422009 engishiki_v42-2_ja.xml#article422009" n="42-2.9"
             type="条" xml:id="article422009">
             <head ana="市町"/>
@@ -3107,7 +3107,7 @@
               <lb/> 縫衣厘　裙厘　帯幡厘　紵 <anchor xml:id="app4220150105"/> 厘 <anchor xml:id="app4220150105e"/> 調布厘　麻厘 <anchor
                 xml:id="app4220150106"/> 続 <anchor xml:id="app4220150106e"/> 麻厘 <lb/> 櫛厘　針厘 <anchor xml:id="app4220150107"/>
               菲 <anchor xml:id="app4220150107e"/> 厘　雑染厘　蓑笠厘　染草厘　土器厘 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00015.tif/full/full/0/default.jpg"/>
               <lb/> 油厘 <anchor xml:id="app4220150108"/> 米 <anchor xml:id="app4220150108e"/> 厘　塩厘　米醤厘　索餅厘　糖厘　心太厘 <lb/>
               海藻厘　菓子厘　干魚厘　生魚厘　牛厘 <lb/>
               <seg rendition="#indent3"> 右、卅三厘西市、 </seg>
@@ -3210,54 +3210,54 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-42/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-42">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5150" xml:id="page5150">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5151" xml:id="page5151">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5152" xml:id="page5152">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5153" xml:id="page5153">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5154" xml:id="page5154">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5155" xml:id="page5155">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5156" xml:id="page5156">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5157" xml:id="page5157">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5158" xml:id="page5158">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5159" xml:id="page5159">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5160" xml:id="page5160">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5161" xml:id="page5161">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5162" xml:id="page5162">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5163" xml:id="page5163">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5164" xml:id="page5164">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42/page5165" xml:id="page5165">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-42%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-42/00016.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v5.xml
+++ b/TEI編集用/engishiki_v5.xml
@@ -1372,7 +1372,7 @@
   <text>
     <body>
       <div ana="斎宮" n="5" type="巻" xml:id="volume5">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai05">
           <p xml:id="shudai0501"> 延喜式巻第五〈 <orgName corresp="#神祇官"> 神祇 </orgName> 五〉 </p>
         </div>
@@ -1388,7 +1388,7 @@
               凡天皇即位者、定伊勢大神宮斎王、仍簡内親王未嫁者卜之、〈若無内親王者、依世次、簡定女王卜之、〉訖即遣勅使於彼家、 告示事由、 <orgName corresp="#神祇官"> 神祇 </orgName>
               祐已上一人、率僚下随勅使共向、卜部解除、神部以木綿着賢木、立殿四面及内外門、〈賢木・木綿所司儲之、解除料散米・酒肴等本家儲之、〉 其後択日時、百官為大祓、〈同尋常二季儀、〉 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00003.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00003.tif/full/full/0/default.jpg"/>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051002 engishiki_v5_en.xml#article051002" n="5.2" type="条"
             xml:id="article051002">
             <head ana="祓料"/>
@@ -1431,7 +1431,7 @@
             <head ana="忌詞"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05100501 engishiki_v5_en.xml#item05100501" xml:id="item05100501"
                 ><anchor xml:id="app0510050101"/> 凡 <anchor xml:id="app0510050101e"/> 忌詞、内七言、仏称中子、経称染紙、塔称阿 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00004.tif/full/full/0/default.jpg"/>
               良々伎、寺称瓦葺、僧称髪長、尼称女髪長、斎称片膳、 外七言、死称奈保留、病称夜須美、哭称塩垂、血称阿世、打称撫、 <anchor xml:id="app0510050102"/> 宍 <anchor
                 xml:id="app0510050102e"/> 称菌、墓称壌、又別忌詞、堂称香燃、優婆塞称角筈、 </p>
             <app from="#app0510050101" to="#app0510050101e">
@@ -1459,7 +1459,7 @@
               盥器韓櫃・装物韓櫃各一合、衣服韓櫃二合、禄物韓櫃六合、〈担夫並用衛士、〉膳部六人、舎人二人、荷領十四人、蔵人所陪従六人、 内侍及院女別当已下、並従車後、〈内侍已下蔵人已上乗私車、釆女・女孺已下乗 <orgName
                 corresp="#馬寮"> 馬寮 </orgName> 車、〉勅使参議一人、院別当一人、 四位二人、五位二人、六位四人、並前駆、左右近衛・左右兵衛各二人、左右門部各二人、左右火長各十人供奉、 <orgName
                 corresp="#京職"> 左 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00005.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00005.tif/full/full/0/default.jpg"/>
                 右京職 </orgName> 官人、率兵士已上迎候、 <placeName corresp="#山城国"> 山城 </placeName> 国司率郡司候京極路、弁一人、史一人、史生二人、官掌一人、
               率供奉諸司就禊所行事、斎王到幕、臨流而禊、 <orgName corresp="#神祇官"> 神祇官 </orgName> 中臣進麻、宮主読祓詞、訖即賜勅使已下饌并禄、〈弁官 <anchor
                 xml:id="app0510060103"/> 録 <anchor xml:id="app0510060103e"/> 見参、付院別当之、〉 既而廻帰入初斎院、即卜定供膳井立賢木、 </p>
@@ -1513,7 +1513,7 @@
             <head ana="初斎院祓清料"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05100801 engishiki_v5_en.xml#item05100801" xml:id="item05100801">
               斎王入初斎院祓清其院料 <lb/> 庸布二段、木綿三斤、麻四斤、烏装大刀二口、弓二張、矢卌隻、鹿角四頭、鹿皮四張、鍬 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00006.tif/full/full/0/default.jpg"/>
               四口、米・酒・腊・塩各四斗、鰒・堅魚各五斤、 海藻・滑海藻・雑海菜各九斤、柏廿把、稲四束、盆四口、匏四柄、輿籠一脚、葉薦二枚、馬二疋、祝詞料庸布五段、短帖一枚、夫二人、 </p>
           </div>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051009 engishiki_v5_en.xml#article051009" n="5.9" type="条"
@@ -1541,7 +1541,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05101101 engishiki_v5_en.xml#item05101101" xml:id="item05101101">
               朔日庭火祭〈野宮・斎宮准此、〉 <lb/> 五色薄絁各四尺、倭文二尺、木綿八両、麻一斤、庸布二段、鍬四口、米・酒各四升、鰒二斤、堅魚・海藻各三斤、腊四升、塩二升二合、 <anchor
                 xml:id="app0510110101"/> 柏二把 <anchor xml:id="app0510110101e"/> 、𤭅・坏各 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00007.tif/full/full/0/default.jpg"/>
               二口、水瓫一口、 </p>
             <app from="#app0510110101" to="#app0510110101e">
               <lem wit="#条本"> 柏二把 </lem>
@@ -1580,7 +1580,7 @@
                 xml:id="app0510140103"/> 盛 <anchor xml:id="app0510140103e"/>
               緑袋、一雨笠、盛油絁袋、並加志部、〉捧壺二口、〈加柄并志部〉沓筥一合、車榻一脚、膳櫃四合、〈各加榻并朸、〉銀 <anchor xml:id="app0510140104"/> 飯 <anchor
                 xml:id="app0510140104e"/> 笥一合、 銀水鋎一合、銀盞一具、銀鍋子一口、銀匕四枚、漆樽二合、手湯戸一合、〈加台、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00008.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00008.tif/full/full/0/default.jpg"/>
               手洗一口、楾一合、貫簀一枚、雕木一 <anchor xml:id="app0510140105"/> 具 <anchor xml:id="app0510140105e"/> 、
               大壺一合、黒漆燈台四本、軽幄一具、床一脚、鎮子十二枚、韓櫃十合、〈已上供物、〉絁六十四疋、黄絁六疋、帛卅二疋、綿百八十屯、 調布八十六 <anchor xml:id="app0510140106"/> 段 <anchor
                 xml:id="app0510140106e"/> 、〈已上、命婦已下舎人已上装束、〉車副廿四人、取物十人、装束卅四具、薬袋卅四枚、 </p>
@@ -1643,7 +1643,7 @@
             xml:id="article051016">
             <head ana="食法"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05101601 engishiki_v5_en.xml#item05101601" xml:id="item05101601"> 食法 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00009.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00009.tif/full/full/0/default.jpg"/>
               五位、〈米二升、酒一升、東鰒・ <anchor xml:id="app0510160101"/>
               <placeName corresp="#隠伎国"> 隠岐 </placeName>
               <anchor xml:id="app0510160101e"/>
@@ -1694,7 +1694,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05101801 engishiki_v5_en.xml#item05101801" xml:id="item05101801">
               造野宮畢祓料 <lb/> 庸布二段、木綿三斤、麻四斤、烏装横刀二口、弓二張、矢卌隻、鹿角四頭、鹿皮四張、鍬四口、米・酒各四斗、稲四束、 <anchor xml:id="app0510180101"/> 鰒 <anchor
                 xml:id="app0510180101e"/> ・堅魚各五斤、 雑腊 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00010.tif/full/full/0/default.jpg"/>
               四斗、海藻・ <anchor xml:id="app0510180102"/> 滑海藻・雑海菜各 <anchor xml:id="app0510180102e"/>
               九斤、塩四斗、盆四口、匏四柄、槲廿把、輿籠一口、葉薦二枚、馬二疋、祝詞料庸布五段、 </p>
             <app from="#app0510180101" to="#app0510180101e">
@@ -1755,7 +1755,7 @@
             <head ana="野宮祓清料"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05102101 engishiki_v5_en.xml#item05102101" xml:id="item05102101">
               斎王遷入野宮祓清其宮料 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00011.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00011.tif/full/full/0/default.jpg"/>
               庸布二 <anchor xml:id="app0510210101"/> 段 <anchor xml:id="app0510210101e"/>
               、木綿・麻各二斤、鹿皮二張、鍬二口、米・酒各二斗、稲四束、鰒・堅魚各五斤、雑腊二斗、海藻・ <anchor xml:id="app0510210102"/> 滑海藻各 <anchor
                 xml:id="app0510210102e"/> 十斤、塩四升、盆二口、 匏二柄、槲四把、輿籠一脚、裹葉薦二枚、帖一枚、𤭅二口、祝詞料庸布五段、夫二人、 </p>
@@ -1807,7 +1807,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05102301 engishiki_v5_en.xml#item05102301" xml:id="item05102301">
               六月祭〈十二月准此〉 <lb/> 月次祭 <lb/> 右、供神調度、准祈年祭、但除鍬、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00012.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00012.tif/full/full/0/default.jpg"/>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051024 engishiki_v5_en.xml#article051024" n="5.24" type="条"
             xml:id="article051024">
             <head ana="月次祭大殿祭"/>
@@ -1863,7 +1863,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05102601 engishiki_v5_en.xml#item05102601" xml:id="item05102601">
               野宮六月晦日大祓〈十二月准此、〉 <lb/> 庸布二段、木綿二斤、枲八両、麻四斤、大刀二口、弓二張、篦一百隻、鍬二口、 <anchor xml:id="app0510260101"/> 鳥 <anchor
                 xml:id="app0510260101e"/> 羽二翼、鹿角二頭、鹿皮二張、 米・酒各二斗、稲四束、鰒二 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00013.tif/full/full/0/default.jpg"/>
               斤、堅魚四斤、海藻・ <anchor xml:id="app0510260102"/> 滑海藻 <anchor xml:id="app0510260102e"/>
               <anchor xml:id="app0510260103"/> 各 <anchor xml:id="app0510260103e"/>
               十斤、腊・塩各二斗、水盆二口、匏二柄、薦二枚、馬二疋、〈其在国之日四疋、〉祝詞料庸布五段、短帖一枚、 </p>
@@ -1907,7 +1907,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05102901 engishiki_v5_en.xml#item05102901" xml:id="item05102901">
               十一月祭 <lb/> 新嘗祭廿八座〈炊殿忌火・庭火神二前、水部忌火・庭火神二前、殿部御竈神一前、御川水神一前、酒殿神一前、膳部御食神一前、大炊竈神一前、自余供祈年祭・月 <anchor
                 xml:id="app0510290101"/> 次 <anchor xml:id="app0510290101e"/> 神是、〉 <lb/> 座別絹五尺、倭文并五色薄絁各一尺、庸 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00014.tif/full/full/0/default.jpg"/>
               布一丈四尺、木綿二両、麻五両、酒四升、鰒・堅魚・海藻・ <anchor xml:id="app0510290102"/> 滑海藻 <anchor xml:id="app0510290102e"/> 各六両、腊二升、塩一升、
               壺・坏各一口、馬一疋、〈宮売神料缶二口、匏二柄、短帖一枚、〉 <lb/> 右、供神料物如前、但預祈年神、座別加槍鋒一口、其惣祭所須葉薦六枚、祝詞料庸布五段、造幣忌部三人明衣料布一 <anchor
                 xml:id="app0510290103"/> 段 <anchor xml:id="app0510290103e"/> 三丈五尺、 </p>
@@ -1936,7 +1936,7 @@
               米四斗、粟二斗、筥十四合、〈径一尺五寸、〉麁筥二合、明櫃三合、案十脚、切案二脚、土火爐二脚、槌・砧各二枚、土盤・椀・堝各十口、 陶椀八口、盤廿口、鉢八口、瓼五口、平居𤭅五口、都婆波・多志良加各四口、 <anchor
                 xml:id="app0510300103"/> 土盆、陶叩盆四口 <anchor xml:id="app0510300103e"/>
               、匜八口、土手湯盆・陶手洗各二口、洗盤六口、酒盞十口、片垸廿口、〈十口陶、〉高坏廿口、〈十口陶、〉 盆四口、酒垂四口、筥坏廿口、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00015.tif/full/full/0/default.jpg"/>
               陶臼二口、蝦鰭槽二隻、匏十八柄、〈小二、〉油三升、槲四俵、日蔭二荷、 </p>
             <app from="#app0510300101" to="#app0510300101e">
               <lem wit="#土本 #条本"> 暴 </lem>
@@ -2003,7 +2003,7 @@
             <head ana="卜戸座火炬"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05103501 engishiki_v5_en.xml#item05103501" xml:id="item05103501">
               卜戸座一人、〈取 <placeName corresp="#山城国"> 山城国 </placeName> 愛宕郡鴨県主氏童子、〉 <lb/> 火炬二人〈取同国葛野郡秦氏童女、〉 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00016.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00016.tif/full/full/0/default.jpg"/>
               右、始自初斎院至于参入大神宮奉仕、其斎王入伊勢斎宮 <anchor xml:id="app0510350101"/> 畢、即 <anchor xml:id="app0510350101e"/> 各替却、 </p>
             <app from="#app0510350101" to="#app0510350101e">
               <lem wit="#条本補書"> 畢、即 </lem>
@@ -2052,7 +2052,7 @@
               年料供物 <lb/> 絹七十二疋五丈五寸、長絹十五疋、白絹十疋、帛廿疋、白綾二疋、綿一百七十二屯、紵五 <anchor xml:id="app0510370101"/> 段 <anchor
                 xml:id="app0510370101e"/> 四丈、細布一 <anchor xml:id="app0510370102"/> 段 <anchor xml:id="app0510370102e"/>
               二丈二尺、糸十斤、〈已上冬御服料、自九月迄 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00017.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00017.tif/full/full/0/default.jpg"/>
               二月、〉 絹六十疋、帛卅疋、綿一百屯、〈已上夏御服料、自三月迄八月、〉 </p>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05103702 engishiki_v5_en.xml#item05103702" xml:id="item05103702">
               斗帳一具、壁代帳十一条、幌三条、〈 <orgName corresp="#縫殿寮"> 縫殿寮 </orgName> 縫備、毎年供之、但斗帳骨 <orgName corresp="#内匠寮"> 内匠寮 </orgName>
@@ -2075,7 +2075,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05103705 engishiki_v5_en.xml#item05103705" xml:id="item05103705">
               調韓櫃五合、〈一合主神所料、二合膳部所料、一合酒部所料、一合水部所料、〉 <anchor xml:id="app0510370501"/> 板 <anchor xml:id="app0510370501e"/>
               笥・藺笥各五合、折櫃十四合、〈八合膳部所料、二合水部所料、四合戸座所料、〉 杓廿三柄、〈八柄膳部所料、三柄酒部 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00018.tif/full/full/0/default.jpg"/>
               所料、十柄水部所料、二柄戸座所料、〉木盤一百八十二口、〈百六十二口膳部所料、廿口酒部所料、〉 水瓺麻笥 <anchor xml:id="app0510370502"/> 六 <anchor
                 xml:id="app0510370502e"/> 口、〈二口膳部所料、一口酒部所料、二口水部所料、 <anchor xml:id="app0510370503"/> 一 <anchor
                 xml:id="app0510370503e"/> 口戸座所料、〉 <anchor xml:id="app0510370504"/> 籬 <anchor xml:id="app0510370504e"/>
@@ -2092,7 +2092,7 @@
               韓竈二口、銅旅竈一具、〈長用、〉木蓋十一枚、 鉄火爐一枚、〈長用、〉土火爐四枚、𨨞一柄、小𨨞二柄、酒槽六隻、釜四口、〈一口受一石、二口各受五斗、煎釜一口、受五斗、長用、〉箕三枚、簀四枚、小匏卅二 <anchor
                 xml:id="app0510370701"/> 柄 <anchor xml:id="app0510370701e"/> 、橧一口、〈受二石、〉円槽三隻、
               洗槽三隻、御前案三脚、〈長各三尺、高八寸、広一尺八寸、〉外居案五脚、〈長各四尺、広二尺、高二尺八寸、〉御水案二脚、匜・手洗 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00019.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00019.tif/full/full/0/default.jpg"/>
               各一口、 手水案二脚、酒案一脚、〈已上五脚、長各三尺、広一尺八寸、高一尺八寸、〉中取八脚、切案六脚、酒垂一口、塩臼二口、槲案四脚、砥一顆、小𨨞三柄、鑿三枚、〈已上三物、主神所料、〉
               鍬八口、〈掃除料、〉塩五石、〈漬雑給菜料、〉黒米卌石、〈雑給酒料、〉𤭖五口、〈長用、〉瓼五口、〈長用、〉缶十口、油一斗二升、油坏一百廿口、 後盤卌口、平𤭅二口、〈十二月晦夜料、〉墨三廷、 </p>
             <app from="#app0510370101" to="#app0510370101e">
@@ -2229,7 +2229,7 @@
               紫菜・海松各二斤十三両、海藻・凝海菜各十一斤四両、塩・搗 <anchor xml:id="app0510380107"/> 栗 <anchor xml:id="app0510380107e"/> 各三斗、生 <anchor
                 xml:id="app0510380108"/> 栗 <anchor xml:id="app0510380108e"/> 六斗、豉六升、醤二斗四升、醤瓜卅顆、味醤一斗二升、糖一斗五升、
               糯米・大豆・小豆・小麦・黍子・胡麻子・葟 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00020.tif/full/full/0/default.jpg"/>
               子各三斗、米二斗一升、酢一斗二升、酒二斛四斗、汁槽一斗五升、油二斗四升、〈供料油六升、燈油一斗八升、〉
               瓫十口、堝卅口、大垸十合、鋺形二百口、片盤四百口、枚片坏六百口、窪坏三百八十口、酒盞・酒台各十五具、椀七十合、齏坏六十口、
               布四尺三寸五分、松明三百把、薪五千四百斤、炭廿四石、藁卅囲、紙七十張、〈五十張雑用料、廿張主神所料、〉筆三管、〈二管雑用料、一管主神所料、〉亀甲一枚、竹廿株、 </p>
@@ -2288,7 +2288,7 @@
               米一石、糯米一石、大豆二斗、小豆三斗、油一斗、雑腊・鮨各三斗、鰒・堅魚各廿斤、酒一石、〈已上官人以下料、〉 <anchor xml:id="app0510390102"/> 調布十三 <anchor
                 xml:id="app0510390103"/> 段 <anchor xml:id="app0510390103e"/> 三丈六尺 <anchor xml:id="app0510390102e"/>
               、〈膳部四人、水部・酒部・炊部・殿部各三人、掃部二人、別衫料二丈、褠・襅 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00021.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00021.tif/full/full/0/default.jpg"/>
               料八尺、女孺三人襅 <anchor xml:id="app0510390104"/> 料 <anchor xml:id="app0510390104e"/> 各四尺、仕丁一人褠・襅料八尺、〉 </p>
             <app from="#app0510390101" to="#app0510390101e">
               <lem wit="#条本 #近本傍書"> 栗 </lem>
@@ -2387,7 +2387,7 @@
               <note> 在　土本・条本等「仕」。近本により改める。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00022.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00022.tif/full/full/0/default.jpg"/>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051043 engishiki_v5_en.xml#article051043" n="5.43" type="条"
             xml:id="article051043">
             <head ana="造備雑物"/>
@@ -2403,7 +2403,7 @@
               塗 <anchor xml:id="app0510430301e"/> 、〉銀飯笥一合、銀酒盞一具、銀鍋子一口、銀水鋺一合、 銀匕一枚、 <anchor xml:id="app0510430302"/> 板 <anchor
                 xml:id="app0510430302e"/> 笥二合、小膳櫃一合、膳櫃六合、下案六脚、厨韓櫃一合、膳案三脚、酒案一脚、粥案一脚、切案一脚、明櫃一合、〈加筥形、〉
               柳筥七合、麁筥四合、紵巾一条、絹篩五口、調布篩二口、帒七口、拭布三条、〈長各一丈、〉塗漆樽 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00023.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00023.tif/full/full/0/default.jpg"/>
               二合、塗漆匜一口、塗漆手洗二口、轆轤槽二口、捧坩三口、 木盤七口、負𤭅四口、平𤭅二口、陶坩二口、手洗二口、洗盤二口、 <anchor xml:id="app0510430303"/> 齏 <anchor
                 xml:id="app0510430303e"/> 鉢二口、筯坩二口、杓三柄、匏四柄、打刀子一枚、檜朸卅 <anchor xml:id="app0510430304"/> 枝 <anchor
                 xml:id="app0510430304e"/> 、 </p>
@@ -2416,7 +2416,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05104305 engishiki_v5_en.xml#item05104305" xml:id="item05104305">
               両面六疋一丈一尺七寸、緋帛十七疋五丈八尺九寸、緋東絁二丈九尺一寸、緑帛五疋九寸、縹帛六疋四丈三尺、 紺東絁四疋二丈二尺、黄帛八疋五丈九尺三寸、生綾三丈一尺三寸、白綾一疋三丈一尺二寸、 <anchor
                 xml:id="app0510430501"/> 帛 <anchor xml:id="app0510430501e"/> 八 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00024.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00024.tif/full/full/0/default.jpg"/>
               尺、橡東絁二疋、帛廿一疋二丈二尺、生絁十四疋五丈五尺七寸、 東絁三丈二尺二 <anchor xml:id="app0510430502"/> 寸 <anchor xml:id="app0510430502e"/> 、
                 <anchor xml:id="app0510430503"/> 色 <anchor xml:id="app0510430503e"/>
               綾三丈七尺、緋糸十九斤一両、緑糸一斤一両、紺糸四両、縹糸一斤三両、黄糸十四両、橡糸八両、練糸二斤九両二分、生糸一斤二両、調綿五十三屯一両、 縹細布一丈七尺、紺調布二 <anchor
@@ -2428,7 +2428,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05104306 engishiki_v5_en.xml#item05104306" xml:id="item05104306">
               金薄卌枚、熟銅大五十七斤七両、半熟銅十八斤、鉄五十一斤四両、調韓櫃七合、薄紙七十三張、紙三百廿四張、墨二廷、筆十管、掃墨九升一合、
               黒葛五斤、油四升五合、〈一升五合荏、二升槾椒、一升胡麻、〉荒筥四合、糯米八升二合、小麦一斗二升二合、酢三 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00025.tif/full/full/0/default.jpg"/>
               斗五升、 </p>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05104307 engishiki_v5_en.xml#item05104307" xml:id="item05104307"
                 ><anchor xml:id="app0510430701"/> 榲 <anchor xml:id="app0510430701e"/> 榑十五村、柏廿把、匏四柄、
@@ -2586,7 +2586,7 @@
               凡斎内親王在京潔斎三年、即毎朔日、着木綿鬘、参入斎殿、遥拝大神、時先供御麻、次鬘木綿、其料 <placeName corresp="#安芸国"> 安芸 </placeName> 木綿四両、麻二斤、 <anchor
                 xml:id="app0510450101"/> 〈別当已下料在此内、〉 <anchor xml:id="app0510450101e"/>
               別当大夫已下卜食者、共再拝両段、但九月・六月・十二月不参、至十六七日参入、再拝両段、長拍手両段、斎王不拍手、斎終之後、乃向伊勢大神宮、 其 <anchor xml:id="app0510450102"/> 野宮内外 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00026.tif/full/full/0/default.jpg"/> 屋
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00026.tif/full/full/0/default.jpg"/> 屋
                 <anchor xml:id="app0510450102e"/> 并垣之類、給 <orgName corresp="#神祇官"> 神祇官 </orgName>
               中臣、出居殿御座・装束之類、給主神司中臣、寝殿内雑物、給同司忌部、但金・銀器及釜・甕之類、納斎王家、 </p>
             <app from="#app0510450101" to="#app0510450101e">
@@ -2672,7 +2672,7 @@
             <head ana="朝庭大祓料"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05105001 engishiki_v5_en.xml#item05105001" xml:id="item05105001"
                 ><anchor xml:id="app0510500101"/> 凡 <anchor xml:id="app0510500101e"/> 斎王将入大神宮、八月晦日朝庭大祓料、庸布二段、木綿・麻各大四斤、鹿皮四張、鹿
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00027.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00027.tif/full/full/0/default.jpg"
               /> 角四枝、大刀四口、弓四枝、箭四具、鍬四口、 <anchor xml:id="app0510500102"/> 葈 <anchor xml:id="app0510500102e"/> 一斤、短帖一枚、
               酒・米各四斗、稲四束、鰒・堅魚各八斤、海藻廿六斤、滑海藻十斤、雑海菜八斤、腊七斗、塩四斗、水戸四口、匏四柄、薦二枚、馬二疋、祝詞軾料庸布五段、 </p>
             <app from="#app0510500101" to="#app0510500101e">
@@ -2764,7 +2764,7 @@
               使四位布十 <anchor xml:id="app0510540201"/> 段 <anchor xml:id="app0510540201e"/> 、五位布五 <anchor xml:id="app0510540202"
               /> 段 <anchor xml:id="app0510540202e"/> 、六位絁一疋、綿一屯、布一 <anchor xml:id="app0510540203"/> 段 <anchor
                 xml:id="app0510540203e"/> 、唯 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00028.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00028.tif/full/full/0/default.jpg"/>
               忌部布三 <anchor xml:id="app0510540204"/> 段 <anchor xml:id="app0510540204e"/> 、 <orgName corresp="#斎宮寮"> 斎宮
               </orgName> 頭絹十疋、綿廿屯、布廿 <anchor xml:id="app0510540205"/> 段 <anchor xml:id="app0510540205e"/> 、助絹八疋、綿十五屯、布十五
                 <anchor xml:id="app0510540206"/> 段 <anchor xml:id="app0510540206e"/> 、 主神司中臣・忌部、 <orgName corresp="#斎宮寮"> 寮
@@ -2851,7 +2851,7 @@
                 xml:id="app0510540305e"/> 、三等女孺各絹六疋、綿五屯、布三 <anchor xml:id="app0510540306"/> 段 <anchor xml:id="app0510540306e"
               /> 、殿守各雑色帛四疋、綿四屯、布二 <anchor xml:id="app0510540307"/> 段 <anchor xml:id="app0510540307e"/> 、女丁各雑色帛二疋二丈五尺、 貲布一
                 <anchor xml:id="app0510540308"/> 段 <anchor xml:id="app0510540308e"/> 、綿四屯、戸座・火炬小子各絹二疋二丈、綿四屯、布 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00029.tif/full/full/0/default.jpg"/> 二
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00029.tif/full/full/0/default.jpg"/> 二
                 <anchor xml:id="app0510540309"/> 段 <anchor xml:id="app0510540309e"/> 、縹布一丈五尺、 </p>
             <app from="#app0510540301" to="#app0510540301e">
               <lem wit="#土本 #条本 #京博本 #九冊本"> 段 </lem>
@@ -2966,7 +2966,7 @@
                 ><anchor xml:id="app0510580101"/> 凡 <anchor xml:id="app0510580101e"/> 斎内親王発日、所司預設御座於大極後殿、天皇御 <anchor
                 xml:id="app0510580102"/> 後 <anchor xml:id="app0510580102e"/> 殿、〈不警、〉 <orgName corresp="#神祇官"> 神祇官 </orgName>
               五位中臣 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00030.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00030.tif/full/full/0/default.jpg"/>
               進御麻、史一人行麻於侍従五位以上、 時刻御大極殿、斎内親王下輿入就殿上座、事訖向大神宮、〈事見儀式、〉 </p>
             <app from="#app0510580101" to="#app0510580101e">
               <lem wit="#土本 #条本 #京博本 #九冊本"> 凡 </lem>
@@ -3022,7 +3022,7 @@
               木綿・麻各六斤、米・酒各六升、鰒・堅魚各六斤、腊・塩各六升、海藻・雑海菜各六斤、雑盛六籠、筥𤭅六口、筥四合、〈方一尺七寸、〉席・薦各一枚、夫三人、 </p>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106002 engishiki_v5_en.xml#item05106002" xml:id="item05106002">
               其路次社幣料、絹一疋、糸五絇、綿五屯、木綿一斤、麻二斤、又頓宮五処大 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00031.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00031.tif/full/full/0/default.jpg"/>
               殿祭料、 <placeName corresp="#安芸国"> 安芸 </placeName> 木綿卌枚、凡木綿一斤、亦路間儲幣料、絁一疋、 綿五屯、糸五絇、木綿大一斤、麻大一斤、卜亀甲一枚、並主神司請 <anchor
                 xml:id="app0510600201"/> 領 <anchor xml:id="app0510600201e"/> 祭之、其鎮祓等料者、請受京庫、 </p>
             <app from="#app0510600201" to="#app0510600201e">
@@ -3201,7 +3201,7 @@
                 </row>
                 <row>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00033.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00033.tif/full/full/0/default.jpg"
                     /> 御 <anchor xml:id="app0510610302"/> 饗 <anchor xml:id="app0510610302e"/> 社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 大土御祖社 </cell>
@@ -3316,7 +3316,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106105 engishiki_v5_en.xml#item05106105" xml:id="item05106105">
               <seg rendition="#indent"> 右祭、二月四日供祭、其六月・十二月月次・鎮火・ <anchor xml:id="app0510610501"/> 道饗 <anchor
                   xml:id="app0510610501e"/> ・大殿・御贖・大祓并朔日忌火・ <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00034.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00034.tif/full/full/0/default.jpg"/>
                 庭火等祭供神 <anchor xml:id="app0510610502"/> 雑 <anchor xml:id="app0510610502e"/> 物及明衣・祝詞料皆准在京、但月次祭加火雷神一座、 </seg>
             </p>
             <app from="#app0510610501" to="#app0510610501e">
@@ -3348,7 +3348,7 @@
             </app>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106203 engishiki_v5_en.xml#item05106203" xml:id="item05106203">
               <seg rendition="#indent"> 右五月・十一月晦日、隨近川頭為禊、八月晦日、臨尾野湊為禊、其三時祭月十五日、斎内親王向離宮、行路之間有二処堺祭、〈宮東堭外及多気・度会両郡堺祭之、料物色目在上、〉 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00035.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00035.tif/full/full/0/default.jpg"/>
                 到着禊殿、〈神宮司并 <orgName corresp="#掃部寮"> 掃部 </orgName>
                 司供奉装束、〉主神司中臣為禊、〈料物神宮司儲之、〉大神宮司奉斎王膳、兼賜酒肴勅使已下、次主神司供奉内院大殿祭、〈所須祭物、神宮司儲之、〉
                 然後斎王遷内院〈装束雑具一同禊殿、〉奉夕膳、〈神宮司以料物附所司、但男女官供給弁備行之、〉 </seg>
@@ -3358,7 +3358,7 @@
                 </orgName> 司供奉装束、〉 <anchor xml:id="app0510620401"/> 神宮司 <anchor xml:id="app0510620401e"/>
                 執鬘木綿、入外玉垣門而跪、命婦出受以奉斎王、拍手而執著鬘、 又神宮司持太玉串、入同門而跪、命婦亦転奉斎王、拍手而執、捧入内玉垣 <anchor xml:id="app0510620402"/> 門 <anchor
                   xml:id="app0510620402e"/> 内就座席、〈命婦若女孺二人陪従、〉避席進前再拝両段、訖玉串授命婦、 受転授物忌、受執立瑞垣門西頭、斎王還就本座、宮司宣祝詞、訖物忌・内人奉幣帛案、 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00036.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00036.tif/full/full/0/default.jpg"/>
                 斎王并衆官以下再拝、拍八開手、次拍短手再拝、如此両遍、既而衆官退出、 就解斎殿給酒食、訖入外玉垣門供倭舞、先神宮司以下及主神司・ <orgName corresp="#斎宮寮"> 寮 </orgName>
                 官次第舞、次斎宮女孺四人供五節舞、訖給禄有差、其後斎王還着離宮、主神司中臣候南門奉御麻、 </seg>
             </p>
@@ -3408,7 +3408,7 @@
             <head ana="新嘗祭"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106501 engishiki_v5_en.xml#item05106501" xml:id="item05106501">
               新嘗祭神百十五座〈大十七座、小九十八座、〉 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00037.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00037.tif/full/full/0/default.jpg"/>
               右、供祭雑物、並准祈年、但鎮炊殿并忌 <anchor xml:id="app0510650101"/> 火 <anchor xml:id="app0510650101e"/> ・庭火・大殿祭等、皆准在京、 </p>
             <app from="#app0510650101" to="#app0510650101e">
               <lem wit="#条本 #近本"> 火 </lem>
@@ -3430,7 +3430,7 @@
               廿口、陶埦八口、多志良加四口、 瓶六口、陶鉢八口、盤廿口、高 <anchor xml:id="app0510660106"/> 杯 <anchor xml:id="app0510660106e"/>
               十口、酒盞十口、油三升、切机二脚、叩盆四口、〈已上 <placeName corresp="#美濃国"> 美濃国 </placeName> 充之、〉東鰒二斤十両、薄鰒・ <placeName corresp="#隠伎国">
                 隠伎 </placeName> 鰒各二 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00038.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00038.tif/full/full/0/default.jpg"/>
               斤、堅魚五斤、 煮堅魚十斤、烏賊・螺各十両、鮨鰒二升、干海松二斤、紫菜一斤、海松纏鰒一升、煮塩年魚・醤鮒各二升、干薑二両、清酒・濁酒各二升、米・糯米各一升、
               大豆・小豆・小麦・胡麻子各二升、糯稲四束、糯糒一升、粟糒・葟子糒・黍子糒各二升、椎子・菱子各五升、蓮子・干棗各一升、生 <anchor xml:id="app0510660107"/> 栗 <anchor
                 xml:id="app0510660107e"/> 一斗、搗 <anchor xml:id="app0510660108"/> 栗 <anchor xml:id="app0510660108e"/> 六升、
@@ -3485,7 +3485,7 @@
             </p>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106604 engishiki_v5_en.xml#item05106604" xml:id="item05106604">
               絹五丈一尺、曝布六 <anchor xml:id="app0510660401"/> 段 <anchor xml:id="app0510660401e"/> 二丈八尺五寸、紵布六尺、糸十両、篩二口、麻笥二口、楉案一脚、土大
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00039.tif/full/full/0/default.jpg"
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00039.tif/full/full/0/default.jpg"
               /> 盤二口、油一升、小豆一升、〈以上 <orgName corresp="#斎宮寮"> 寮 </orgName> 充之、〉
               湯槽・円槽・洗足槽各一隻、棚案一脚、板蓋五枚、明櫃二合、筥一合、麁筥一合、燈台二具、匏三柄、菲一両、〈以上 <placeName corresp="#伊勢国"> 当国 </placeName>
               充之、〉池由加一口、由加四口、 叩 <anchor xml:id="app0510660402"/> 盆 <anchor xml:id="app0510660402e"/> 四口、油𤭅一口、油 <anchor
@@ -3553,7 +3553,7 @@
               三丈四尺、紅花六斤、〈已上青摺衣料、〉絹二疋四丈、 曝布六 <anchor xml:id="app0510660702"/> 段 <anchor xml:id="app0510660702e"/>
               六尺、〈已上膳部并女孺等褠・襅料、〉 <lb/>
               <seg rendition="#indent"> 右、小斎人等祭服、 <orgName corresp="#斎宮寮"> 寮 </orgName> 依例充、其賜禄 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00040.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00040.tif/full/full/0/default.jpg"/>
                 一准元日、 </seg>
             </p>
             <app from="#app0510660701" to="#app0510660701e">
@@ -3579,7 +3579,7 @@
               炊部神祭 <lb/> 五色薄絁各三寸、倭文三寸、木綿・麻各一斤、庸布一段、鍬一口、酒四斗、米・糯米各三升、鰒・堅魚・腊各一斤、海藻二斤、鮨二升、塩一升、大豆・小豆各二升、 </p>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106703 engishiki_v5_en.xml#item05106703" xml:id="item05106703">
               酒部神祭 <lb/> 五色薄絁各六寸、倭文六寸、木綿・麻各八両、庸布一段、鍬一口、米・酒各六升、糯米四升、大豆・小豆各一升、鰒・堅魚各一斤、鮨・腊各四升、塩一升、盤五口、食薦一枚、 </p>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00041.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00041.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106704 engishiki_v5_en.xml#item05106704" xml:id="item05106704">
               水部神祭 <lb/> 五色薄絁各六寸、倭文六寸、木綿八両、麻四両、庸布一段、鍬一口、米・酒各二升、鰒・堅魚各八両、鮨一升、海藻八両、塩五合、 </p>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05106705 engishiki_v5_en.xml#item05106705" xml:id="item05106705">
@@ -3603,7 +3603,7 @@
               <note> 二　土本等無し。近本・京博本傍書等により補う。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00042.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00042.tif/full/full/0/default.jpg"/>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051069 engishiki_v5_en.xml#article051069" n="5.69" type="条"
             xml:id="article051069">
             <head ana="斎宮諸神幣"/>
@@ -3642,7 +3642,7 @@
               <note> 別　訳注本この上に「甕」を意補。藤波本・京博本は「甕」を朱補書。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00043.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00043.tif/full/full/0/default.jpg"/>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051071 engishiki_v5_en.xml#article051071" n="5.71" type="条"
             xml:id="article051071">
             <head ana="年料供物"/>
@@ -3679,7 +3679,7 @@
               両面一疋四丈、緋帛五丈七尺、油絁一疋三尺、絹三丈四尺、細布一丈六尺、曝布二丈四尺、綿一屯、糸一絇、麻一斤、水甕二口、水甕麻笥三口、韓竈四具、長刀子二枚、 短刀子五枚、砥一顆、〈以上 <orgName
                 corresp="#斎宮寮"> 寮 </orgName> 充之、〉膳案一脚、菓案一脚、筥笥三合、 <anchor xml:id="app0510710201"/> 板 <anchor
                 xml:id="app0510710201e"/> 笥二合、筯筥一合、麁筥五合、切案二脚、槲案二脚、大案二脚、韓櫃三合、 明櫃八合、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00044.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00044.tif/full/full/0/default.jpg"/>
               大笥五合、別脚案二脚、横筥二合、缶十口、槽一隻、円槽二隻、席八枚、置簀六枚、臼一口、杵二枝、匏廿柄、笥杓廿柄、箕二枚、輦籠四脚、〈以上 <placeName corresp="#伊勢国"> 当国 </placeName>
               充之、〉 <lb/>
               <seg rendition="#indent"> 右、膳部司所請、 </seg>
@@ -3728,7 +3728,7 @@
             </app>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05107105 engishiki_v5_en.xml#item05107105" xml:id="item05107105">
               両面三丈六寸、緋帛二丈四尺七寸、油絁四丈 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00045.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00045.tif/full/full/0/default.jpg"/>
               四尺、絹二丈四尺、薄 <anchor xml:id="app0510710501"/> 絹 <anchor xml:id="app0510710501e"/> 一丈二尺、糸一両、曝布三丈四尺、細布三丈四尺、紵
                 <anchor xml:id="app0510710502"/> 布 <anchor xml:id="app0510710502e"/> 一丈、釿一 <anchor xml:id="app0510710503"/> 柄
                 <anchor xml:id="app0510710503e"/> 、小刀子二柄、 水甕麻笥二口、〈已上 <orgName corresp="#斎宮寮"> 寮 </orgName> 充之、〉坩一口、陶 <anchor
@@ -3781,7 +3781,7 @@
                 xml:id="app0510710601e"/> 二丈一尺七寸、紵布六尺、調布二丈九尺、糸二分、楉案一脚、 油坏・盤各三口、鉄火取堝一口、鉄五廷、鍬二口、〈以上 <orgName corresp="#斎宮寮"> 寮
               </orgName> 充之、〉湯槽一隻、洗床一張、大案二脚、木蓋五枚、洗頭槽一隻、洗足槽一隻、 洗物槽一隻、韓櫃二合、燈台二具、明櫃二合、筥二合、麁筥二合、匏三柄、〈已上 <placeName corresp="#伊勢国"
                 > 当国 </placeName> 充之、〉池由加一口、由加四口、匜一口、𤭅一口、缶二口、叩盆四口、〈以上 <placeName corresp="#美濃国"> 美濃国 </placeName> 充之、〉 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00046.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00046.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent"> 右、殿部司所請、 </seg>
             </p>
             <app from="#app0510710601" to="#app0510710601e">
@@ -3812,7 +3812,7 @@
               升、芒硝 <anchor xml:id="app0510710902"/> 七 <anchor xml:id="app0510710902e"/> 両四銖、防風一両二分四銖、麻黄二両三分四銖、
               蛇銜九両一分、石膏一両三分、芎藭七両三分、大黄一斤四両二分四銖、人参十両、紫 <anchor xml:id="app0510710903"/> 菀 <anchor xml:id="app0510710903e"/>
               二両二分、茈胡五両、黄芩十一両二分二銖、 黄連一 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00047.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00047.tif/full/full/0/default.jpg"/>
               両二銖、皂莢二分一銖、夕薬六両、漏蘆六両一分、連翹十五両、白薟十両二分、蘆茹四両一分、附子九斤十五両、干薑七両二分、
               猪膏六十四斤八両、白朮七斤十両二分、烏頭十四斤四両、半夏二両二分、桔梗九斤五両二分、細辛七斤十四両、呉茱萸一斤六両、 <anchor xml:id="app0510710904"/> 昌 <anchor
                 xml:id="app0510710904e"/> 蒲二両二分、 <anchor xml:id="app0510710905"/> 伏 <anchor xml:id="app0510710905e"/>
@@ -3822,7 +3822,7 @@
               、当帰四両二分、蒴藋一斤一分、商陸四両一分、 <anchor xml:id="app0510710909"/> 𦬣 <anchor xml:id="app0510710909e"/>
               草三斤五両、黄耆四両一分、牡丹四両一分、地楡四両一分、大戟五両一分、玄参三両三分、白頭公三両一分、躑躅花九両一分、 <anchor xml:id="app0510710910"/> 抜 <anchor
                 xml:id="app0510710910e"/> 葜一両一分、 酢二斗五升、砥一顆、両面九尺六寸、油絁九尺六寸、帛四丈一尺、緋帛一丈五寸、絹八尺、紗三尺、布三丈五尺、糸二両、木綿七両、紙八十四張、〈已上 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00048.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00048.tif/full/full/0/default.jpg"/>
               <orgName corresp="#斎宮寮"> 寮 </orgName> 充之、〉 陶坩・叩盆各四口、陶手洗一口、陶椀二合、盤二口、〈已上 <placeName corresp="#美濃国"> 美濃国
               </placeName> 充之、〉筥二合、机二脚、折櫃一合、明櫃一合、大案一脚、麻笥一口、杓一柄、大笥一合、〈已上 <placeName corresp="#伊勢国"> 当国 </placeName> 充之、〉
               薬刀一具、鉄臼一口、杵一 <anchor xml:id="app0510710911"/> 枚 <anchor xml:id="app0510710911e"/>
@@ -3900,7 +3900,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05107201 engishiki_v5_en.xml#item05107201" xml:id="item05107201">
               凡斎内親王月料及節料等、皆准在京、其官人主典已上廿六人、番上一百一人、命婦一人、乳母三人、女孺卅九人、御厠人二人、御洗二人、〈別米二升、塩二夕、〉
               仕丁十五人、駆使丁廿五人、飼丁八人、〈取神郡并神戸仕丁充之、〉今良八人、〈別米二升、塩二夕、〉女丁十人、将従二百七十三人、〈別米一升五合、塩一夕五撮、〉 戸座一人、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00049.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00049.tif/full/full/0/default.jpg"/>
               火炬小女二人、〈別米一升四合、塩一夕四撮、〉宮主并卜部家口四人、〈別米一升五合、塩一夕五撮、〉 </p>
           </div>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051073 engishiki_v5_en.xml#article051073" n="5.73" type="条"
@@ -3953,7 +3953,7 @@
             <head ana="六月"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05107401 engishiki_v5_en.xml#item05107401" xml:id="item05107401">
               凡六月斎内親王参神宮、陪従皆給装束、〈十二月准此、〉諸司主典已上、人別絹三丈五尺、〈供膳官人加褌料布、〉神部六人・卜部三人・膳部八人・炊部三人・ 酒部四人・水部四人・蔵部六人・殿部六人・掃部 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00050.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00050.tif/full/full/0/default.jpg"/>
               四人・今良四人各布二丈、戸座一人布一丈四尺、奏舞女孺四人各絹一疋、自外不給、 </p>
           </div>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051075 engishiki_v5_en.xml#article051075" n="5.75" type="条"
@@ -3995,7 +3995,7 @@
             <head ana="供田墾田"/>
             <p ana="項" corresp="engishiki_v5_ja.xml#item05107701 engishiki_v5_en.xml#item05107701" xml:id="item05107701">
               凡斎内親王到国、初年割正税七百束、供用年料之膳、当郡毎月舂送 <orgName corresp="#斎宮寮"> 寮 </orgName> 家、後年用供 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00051.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00051.tif/full/full/0/default.jpg"/>
               田稲、其供田二町、〈一町在多気郡、一町在度会郡、〉 外供田四町、〈三町在多気郡、一町在飯野郡、〉墾田廿七町八段一百十七歩、〈十七町七十一歩在多気郡、十町八段 <anchor xml:id="app0510770101"/>
               卌 <anchor xml:id="app0510770101e"/> 六歩在飯野郡、〉其外供田地子稲者、 勘納 <orgName corresp="#斎宮寮"> 寮 </orgName>
               家、充供御之闕乏、墾田准郷土估賃租、充 <orgName corresp="#斎宮寮"> 寮 </orgName> 家 <anchor xml:id="app0510770102"/> 雑 <anchor
@@ -4089,7 +4089,7 @@
               庸米一千六百六十七石五斗、〈 <placeName corresp="#伊賀国"> 伊賀 </placeName> 三百 <anchor xml:id="app0510780301"/> 卌 <anchor
                 xml:id="app0510780301e"/> 二石、 <placeName corresp="#伊勢国"> 伊勢 </placeName> 四百七十三石二斗、 <placeName corresp="#参河国">
                 参河 </placeName> 五百五十九石三斗、 <placeName corresp="#美濃国"> 美濃 </placeName> 二百九十三石、〉 舂米一千 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00052.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00052.tif/full/full/0/default.jpg"/>
               三百卅四石八斗、〈 <placeName corresp="#伊勢国"> 伊勢 </placeName> 五百卅四石八斗、就中黒米三百九十五石、 <placeName corresp="#尾張国"> 尾張
               </placeName> 二百石、 <placeName corresp="#参河国"> 参河 </placeName> 二百石、 <placeName corresp="#美濃国"> 美濃 </placeName>
               四百石、〉 糯米十石、小麦十石、大麦一石、粟三石六斗、大豆・小豆各六石、醤大豆十八石、胡麻子一石、葟子一石、〈已上 <placeName corresp="#伊勢国"> 伊勢 </placeName> 、〉 黍子一石、〈
@@ -4133,7 +4133,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05107805 engishiki_v5_en.xml#item05107805" xml:id="item05107805">
               馬秣稲百廿束、〈大神宮司所充、三時祭別 <anchor xml:id="app0510780501"/> 卌 <anchor xml:id="app0510780501e"/> 束、〉蒭四千八 <anchor
                 xml:id="app0510780502"/> 百 <anchor xml:id="app0510780502e"/> 囲、〈半分大神宮司以神郡浪人刈 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00053.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00053.tif/full/full/0/default.jpg"/>
               送、半分国司以国内浪人刈送、〉 </p>
             <app from="#app0510780501" to="#app0510780501e">
               <lem wit="#条本 #九冊本"> 卌 </lem>
@@ -4186,7 +4186,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05108201 engishiki_v5_en.xml#item05108201" xml:id="item05108201">
               凡斎内親王参祭之禊、国司目已上名簿、在前移斎宮令卜、其最合者一人祗承、其三時祭月十五日、大祓処申刀禰数、〈祗承官五位已上令史生申、六位已下自申、〉 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00054.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00054.tif/full/full/0/default.jpg"/>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051083 engishiki_v5_en.xml#article051083" n="5.83" type="条"
             xml:id="article051083">
             <head ana="封戸"/>
@@ -4245,7 +4245,7 @@
               </orgName> 并厨家之料、便 <orgName corresp="#斎宮寮"> 寮 </orgName> 官一人専当其事、勘納功物、随其破損、可加 <anchor xml:id="app0510890102"/>
               修 <anchor xml:id="app0510890102e"/> 理、其立用帳、請 <orgName corresp="#斎宮寮"> 寮 </orgName> 吏判、 若不 <anchor
                 xml:id="app0510890103"/> 営 <anchor xml:id="app0510890103e"/> 小破、妄致大損者、科処勾当官人、但 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00055.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00055.tif/full/full/0/default.jpg"/>
               至于非常異損、随申処分、 </p>
             <app from="#app0510890101" to="#app0510890101e">
               <lem wit="#条本転倒符 #近本傍書"> 分充 </lem>
@@ -4310,7 +4310,7 @@
             <p ana="項" corresp="engishiki_v5_ja.xml#item05109601 engishiki_v5_en.xml#item05109601" xml:id="item05109601">
               凡隍中有失火穢者、随之祓清、其宅人七日不得参入宮中、 </p>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00056.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00056.tif/full/full/0/default.jpg"/>
           <div ana="斎宮" corresp="engishiki_v5_ja.xml#article051097 engishiki_v5_en.xml#article051097" n="5.97" type="条"
             xml:id="article051097">
             <head ana="斎王相代"/>
@@ -4358,186 +4358,186 @@
           </div>
         </div>
         <div type="尾題" xml:id="bidai05">
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00057.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00057.tif/full/full/0/default.jpg"/>
           <p xml:id="bidai0501"> 延喜式巻第五 </p>
         </div>
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-5/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-5">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3904" xml:id="page3904">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3905" xml:id="page3905">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3906" xml:id="page3906">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3907" xml:id="page3907">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3908" xml:id="page3908">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3909" xml:id="page3909">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3910" xml:id="page3910">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3911" xml:id="page3911">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3912" xml:id="page3912">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3913" xml:id="page3913">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3914" xml:id="page3914">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3915" xml:id="page3915">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3916" xml:id="page3916">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3917" xml:id="page3917">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3918" xml:id="page3918">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3919" xml:id="page3919">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3920" xml:id="page3920">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3921" xml:id="page3921">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3922" xml:id="page3922">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3923" xml:id="page3923">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3924" xml:id="page3924">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3925" xml:id="page3925">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3926" xml:id="page3926">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3927" xml:id="page3927">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3928" xml:id="page3928">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3929" xml:id="page3929">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3930" xml:id="page3930">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3931" xml:id="page3931">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3932" xml:id="page3932">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3933" xml:id="page3933">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3934" xml:id="page3934">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3935" xml:id="page3935">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3936" xml:id="page3936">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3937" xml:id="page3937">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3938" xml:id="page3938">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3939" xml:id="page3939">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00036.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3940" xml:id="page3940">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00037.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00037.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3941" xml:id="page3941">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00038.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00038.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3942" xml:id="page3942">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00039.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00039.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3943" xml:id="page3943">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00040.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00040.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3944" xml:id="page3944">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00041.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00041.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3945" xml:id="page3945">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00042.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00042.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3946" xml:id="page3946">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00043.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00043.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3947" xml:id="page3947">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00044.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00044.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3948" xml:id="page3948">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00045.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00045.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3949" xml:id="page3949">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00046.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00046.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3950" xml:id="page3950">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00047.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00047.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3951" xml:id="page3951">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00048.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00048.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3952" xml:id="page3952">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00049.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00049.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3953" xml:id="page3953">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00050.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00050.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3954" xml:id="page3954">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00051.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00051.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3955" xml:id="page3955">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00052.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00052.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3956" xml:id="page3956">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00053.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00053.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3957" xml:id="page3957">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00054.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00054.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3958" xml:id="page3958">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00055.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00055.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3959" xml:id="page3959">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00056.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00056.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3960" xml:id="page3960">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00057.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00057.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5/page3961" xml:id="page3961">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-5%2F00058.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-5/00058.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v8.xml
+++ b/TEI編集用/engishiki_v8.xml
@@ -1393,7 +1393,7 @@
   <text>
     <body>
       <div ana="祝詞" n="8" type="巻" xml:id="volume8">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai08">
           <p xml:id="shudai0801"> 祝詞式</p>
         </div>
@@ -1424,7 +1424,7 @@
             <head ana="祈年祭"/>
             <p ana="項" corresp="engishiki_v8_en.xml#item08100301 engishiki_v8_ja.xml#item08100301" xml:id="item08100301">
               祈年祭<lb/>集侍神主・祝部等諸聞食〈登〉宣、〈神主・祝部等共称唯、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00003.tif/full/full/0/default.jpg"/> 余
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00003.tif/full/full/0/default.jpg"/> 余
                 <anchor xml:id="app0810030101"/>宣<anchor xml:id="app0810030101e"/>准此、〉</p>
             <app from="#app0810030101" to="#app0810030101e">
               <lem wit="#土本 #永本 #右本">宣</lem>
@@ -1485,7 +1485,7 @@
             </app>
             <p ana="項" corresp="engishiki_v8_en.xml#item08100304 engishiki_v8_ja.xml#item08100304" xml:id="item08100304">
               大御巫〈能〉辞 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00004.tif/full/full/0/default.jpg"/>
               竟奉皇神等〈能〉前〈尓〉白〈久〉、神魂・高御魂・生魂・足魂・玉留魂・大宮乃売・大御膳都神・辞代主〈登〉御名者白而辞竟奉者、皇御孫命御世〈乎〉、 <anchor xml:id="app0810030401"
                 />手<anchor xml:id="app0810030401e"/>長御世〈登〉、堅磐〈尓〉常磐〈尓〉斎〈比〉奉、茂御世〈尓〉幸閉奉故、皇吾睦神漏伎命・神漏弥命〈登〉、皇御孫命〈能〉宇豆 <anchor
                 xml:id="app0810030402"/>乃<anchor xml:id="app0810030402e"/>幣帛〈乎〉、称辞竟奉〈 <anchor xml:id="app0810030403"
@@ -1517,7 +1517,7 @@
                 御門〈<anchor xml:id="app0810030601"/>能<anchor xml:id="app0810030601e"/>〉御巫〈 <anchor xml:id="app0810030602"
                 />能<anchor xml:id="app0810030602e"/>〉辞竟奉皇神等〈 <anchor xml:id="app0810030603"/>能<anchor xml:id="app0810030603e"
               />〉前〈尓〉 <anchor xml:id="app0810030604"/>白<anchor xml:id="app0810030604e"/>〈久〉、櫛磐間門命・豊磐間門命〈登〉御名 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00005.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00005.tif/full/full/0/default.jpg"/>
               者白〈弖〉、辞竟奉者、四方〈能〉御門〈尓〉、湯都磐村〈能〉如 <anchor xml:id="app0810030605"/>塞<anchor xml:id="app0810030605e"
               />坐〈弖〉、朝者御門開奉、夕者御門閉奉〈弖〉、疎夫留物〈能〉自下往者下〈乎〉守、自上往者上〈乎〉守、夜〈能〉守・日〈能〉守〈尓〉守奉故、 <anchor xml:id="app0810030606"/>皇<anchor
                 xml:id="app0810030606e"/>御孫命〈能〉宇豆 <anchor xml:id="app0810030607"/>乃<anchor xml:id="app0810030607e"
@@ -1561,7 +1561,7 @@
               />〈志〉坐四方国者、天〈能〉壁立極、国〈能〉退立限、青雲〈能〉靄極、白雲〈能〉墮坐向伏限、青海原者棹 <anchor xml:id="app0810030804"/>柁<anchor
                 xml:id="app0810030804e"/>不干、舟 <anchor xml:id="app0810030805"/>艫<anchor xml:id="app0810030805e"/>〈能〉至留極、大
                 <anchor xml:id="app0810030806"/>海<anchor xml:id="app0810030806e"/>〈尓〉舟満都都 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00006.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00006.tif/full/full/0/default.jpg"/>
               気〈弖〉、自陸往道 <anchor xml:id="app0810030807"/>者<anchor xml:id="app0810030807e"/>、荷緒縛堅〈弖〉、磐根・木根履佐 <anchor
                 xml:id="app0810030808"/>久<anchor xml:id="app0810030808e"
               />弥〈弖〉、馬爪至留限、長道無間〈久〉立都都気〈弖〉、狭国者広〈久〉、峻国者平〈久〉、遠国者八十綱打挂〈弖〉引寄如事、皇大御神〈能〉寄奉〈波〉、荷前者皇大御神〈能〉 <anchor
@@ -1670,7 +1670,7 @@
             <p ana="項" corresp="engishiki_v8_en.xml#item08100310 engishiki_v8_ja.xml#item08100310" xml:id="item08100310">
                 山口坐皇神等〈<anchor xml:id="app0810031001"/>能<anchor xml:id="app0810031001e"/>〉前〈尓〉白〈久〉、飛鳥・石 <anchor
                 xml:id="app0810031002"/>寸<anchor xml:id="app0810031002e"/>・忍 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00007.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00007.tif/full/full/0/default.jpg"/>
               坂・長谷・畝火・耳無〈 <anchor xml:id="app0810031003"/>登<anchor xml:id="app0810031003e"
               />〉御名者白〈弖〉、遠山・近山〈尓〉生立〈留〉大木・小木〈乎〉、本末打切〈弖〉 <anchor xml:id="app0810031004"/>持<anchor xml:id="app0810031004e"
               />参来〈弖〉、皇御 <anchor xml:id="app0810031005"/>孫<anchor xml:id="app0810031005e"/>命〈 <anchor xml:id="app0810031006"
@@ -1847,7 +1847,7 @@
               <rdg wit="#九本">止</rdg>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00008.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00008.tif/full/full/0/default.jpg"/>
           <div ana="祝詞" corresp="engishiki_v8_en.xml#article081004 engishiki_v8_ja.xml#article081004" n="8.4" type="条"
             xml:id="article081004">
             <head ana="春日祭"/>
@@ -1973,7 +1973,7 @@
             <p ana="項" corresp="engishiki_v8_en.xml#item08100402 engishiki_v8_ja.xml#item08100402" xml:id="item08100402">
                 如此仕奉〈尓〉依〈弖〉、今〈母〉去前〈<anchor xml:id="app0810040201"/>母<anchor xml:id="app0810040201e"/>〉、天皇〈我〉朝 <anchor
                 xml:id="app0810040202"/>庭<anchor xml:id="app0810040202e"/>〈乎〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00009.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00009.tif/full/full/0/default.jpg"/>
               平〈久〉安〈久〉、足御世〈乃〉茂御世〈尓〉斎奉〈利〉、常石〈尓〉堅石〈尓〉福閉奉〈利〉、預而仕奉〈 <anchor xml:id="app0810040203"/>流<anchor
                 xml:id="app0810040203e"/>〉処処 <anchor xml:id="app0810040204"/>家<anchor xml:id="app0810040204e"/>・王等卿等〈乎
                 <anchor xml:id="app0810040205"/>母<anchor xml:id="app0810040205e"/>〉平〈久〉、天皇〈我〉朝 <anchor xml:id="app0810040206"
@@ -2122,7 +2122,7 @@
                 xml:id="app0810050212e"/>・辺津藻葉〈尓〉至〈万弖〉、置足〈弖〉奉〈久 <anchor xml:id="app0810050213"/>登<anchor
                 xml:id="app0810050213e"/>〉、皇神前〈尓〉白賜〈部 <anchor xml:id="app0810050214"/>止<anchor xml:id="app0810050214e"
               />〉宣、如此奉宇豆〈乃〉幣帛〈乎〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00010.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00010.tif/full/full/0/default.jpg"/>
               安幣帛〈 <anchor xml:id="app0810050215"/>能<anchor xml:id="app0810050215e"/>〉足幣帛〈 <anchor xml:id="app0810050216"
                 />止<anchor xml:id="app0810050216e"/>〉、皇神御心平〈久〉安〈 <anchor xml:id="app0810050217"/>久<anchor
                 xml:id="app0810050217e"/>〉聞食〈弖〉、皇御孫命〈 <anchor xml:id="app0810050218"/>能<anchor xml:id="app0810050218e"/>〉長御膳〈
@@ -2285,7 +2285,7 @@
                 />満<anchor xml:id="app0810050313e"/>置〈弖〉奉〈牟 <anchor xml:id="app0810050314"/>登<anchor xml:id="app0810050314e"
               />〉、王等・臣等・百官人等、倭国〈乃〉六御県〈 <anchor xml:id="app0810050315"/>能<anchor xml:id="app0810050315e"/>〉刀 <anchor
                 xml:id="app0810050316"/>禰<anchor xml:id="app0810050316e"/>、男女〈尓〉至〈万弖〉、今年某 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00011.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00011.tif/full/full/0/default.jpg"/>
               月某日、諸参 <anchor xml:id="app0810050317"/>出<anchor xml:id="app0810050317e"/>来〈弖〉、皇神前〈尓〉宇事物頸根築抜〈弖〉、朝日〈乃〉豊逆 <anchor
                 xml:id="app0810050318"/>登<anchor xml:id="app0810050318e"/>〈尓〉称辞竟奉〈久乎〉、神主・祝部等諸聞食〈止〉宣、 </p>
             <app from="#app0810050301" to="#app0810050301e">
@@ -2381,7 +2381,7 @@
                 xml:id="app0810060111e"/>、宇気比賜〈支〉、 <anchor xml:id="app0810060112"/>是以、皇御孫命大御夢〈尓〉悟奉〈久〉、天下〈乃〉 <anchor
                 xml:id="app0810060113"/>公<anchor xml:id="app0810060113e"/>民〈乃〉<anchor xml:id="app0810060112e"
               />作作物〈乎〉、悪風・荒水〈尓〉相〈都都〉、不成傷〈波〉、我御名者天〈乃〉御柱〈乃〉命・国〈乃〉御 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00012.tif/full/full/0/default.jpg"/> 柱〈
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00012.tif/full/full/0/default.jpg"/> 柱〈
                 <anchor xml:id="app0810060114"/>能<anchor xml:id="app0810060114e"/>〉命 <anchor xml:id="app0810060115"
                 />〈止〉<anchor xml:id="app0810060115e"/>、御名者悟奉〈弖〉、吾前〈尓〉奉〈牟〉幣帛者、御服者明妙・照妙・和妙・荒妙、 <anchor xml:id="app0810060116"
                 />五<anchor xml:id="app0810060116e"/>色〈乃〉物、楯・戈・御馬〈尓〉御鞍具〈弖〉、品品〈乃〉幣帛備〈弖〉、吾宮者朝日〈乃〉日向処、夕日〈乃〉日隠処〈乃〉、竜田〈 <anchor
@@ -2526,7 +2526,7 @@
                 xml:id="app0810060213"/>毛<anchor xml:id="app0810060213e"/>〈乃〉荒 <anchor xml:id="app0810060214"/>物、大<anchor
                 xml:id="app0810060214e"/>
               <anchor xml:id="app0810060215"/>野<anchor xml:id="app0810060215e"/>原生物者、甘 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00013.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00013.tif/full/full/0/default.jpg"/>
               菜・辛菜、青海原〈 <anchor xml:id="app0810060216"/>仁<anchor xml:id="app0810060216e"/>〉住物者、鰭〈 <anchor
                 xml:id="app0810060217"/>能<anchor xml:id="app0810060217e"/>〉広物・鰭〈 <anchor xml:id="app0810060218"/>能<anchor
                 xml:id="app0810060218e"/>〉狭物、奥都藻 <anchor xml:id="app0810060219"/>菜<anchor xml:id="app0810060219e"/>・辺都藻
@@ -2733,7 +2733,7 @@
                 xml:id="app0810070110e"/>〉千木高知〈弖〉、天〈 <anchor xml:id="app0810070111"/>能<anchor xml:id="app0810070111e"/>〉御蔭・日〈
                 <anchor xml:id="app0810070112"/>能<anchor xml:id="app0810070112e"/>〉御蔭〈 <anchor xml:id="app0810070113"
                 />登<anchor xml:id="app0810070113e"/>〉定 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00014.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00014.tif/full/full/0/default.jpg"/>
               奉〈弖〉、 <anchor xml:id="app0810070114"/>神主<anchor xml:id="app0810070114e"/>〈尓〉<orgName corresp="#神祇官"
                 >神祇</orgName>某官位姓名定〈弖〉、進〈 <anchor xml:id="app0810070115"/>流<anchor xml:id="app0810070115e"/>〉神 <anchor
                 xml:id="app0810070116"/>財<anchor xml:id="app0810070116e"/>〈波〉、御弓・御 <anchor xml:id="app0810070117"/>太<anchor
@@ -2936,7 +2936,7 @@
                 xml:id="app0810080104e"/>弖〉供奉来〈 <anchor xml:id="app0810080105"/>流<anchor xml:id="app0810080105e"/>〉皇御神〈
                 <anchor xml:id="app0810080106"/>能<anchor xml:id="app0810080106e"/>〉広前〈尓〉白給〈久〉、皇御神〈 <anchor
                 xml:id="app0810080107"/>能<anchor xml:id="app0810080107e"/>〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00015.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00015.tif/full/full/0/default.jpg"/>
               乞〈比〉給〈万比之〉任〈尓〉、此所〈 <anchor xml:id="app0810080108"/>能<anchor xml:id="app0810080108e"/>〉底〈津〉石根〈尓〉宮柱広敷立、高天〈
                 <anchor xml:id="app0810080109"/>能<anchor xml:id="app0810080109e"/>〉原〈 <anchor xml:id="app0810080110"
                 />仁<anchor xml:id="app0810080110e"/>〉千木高知〈弖〉、天〈 <anchor xml:id="app0810080111"/>能<anchor
@@ -3152,7 +3152,7 @@
               <lem wit="#土本 #永本 #右本">登</lem>
               <rdg wit="#九本">止</rdg>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00016.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00016.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v8_en.xml#item08100902 engishiki_v8_ja.xml#item08100902" xml:id="item08100902">
                 高天原〈<anchor xml:id="app0810090201"/>仁<anchor xml:id="app0810090201e"/>〉神留坐、皇睦神漏伎命・神漏弥命以、天社・ <anchor
                 xml:id="app0810090202"/>国社<anchor xml:id="app0810090202e"/>〈 <anchor xml:id="app0810090203"/>登<anchor
@@ -3240,7 +3240,7 @@
               />〉敷坐、下都磐根〈尓〉宮柱太知立、高天原〈 <anchor xml:id="app0810090406"/>仁<anchor xml:id="app0810090406e"
               />〉千木高知〈弖〉、皇御孫命瑞〈乃〉御舎仕奉〈弖〉、天御蔭・日御蔭〈 <anchor xml:id="app0810090407"/>登<anchor xml:id="app0810090407e"
               />〉隠坐〈弖〉、四方国〈乎〉安国 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00017.tif/full/full/0/default.jpg"/> 〈
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00017.tif/full/full/0/default.jpg"/> 〈
                 <anchor xml:id="app0810090408"/>登<anchor xml:id="app0810090408e"/>〉平〈久〉知食〈須〉故、皇御孫命〈 <anchor
                 xml:id="app0810090409"/>能<anchor xml:id="app0810090409e"/>〉宇豆〈乃〉幣帛〈乎〉、称辞竟奉〈久 <anchor xml:id="app0810090410"
                 />登<anchor xml:id="app0810090410e"/>〉宣、 </p>
@@ -3405,7 +3405,7 @@
               />〉坐四方国者、天〈 <anchor xml:id="app0810090706"/>能<anchor xml:id="app0810090706e"/>〉壁立極、国〈 <anchor
                 xml:id="app0810090707"/>能<anchor xml:id="app0810090707e"/>〉退立限、青雲〈 <anchor xml:id="app0810090708"/>能<anchor
                 xml:id="app0810090708e"/>〉靄極、白雲〈 <anchor xml:id="app0810090709"/>能<anchor xml:id="app0810090709e"/>〉向伏限、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00018.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00018.tif/full/full/0/default.jpg"/>
               青海原者棹 <anchor xml:id="app0810090710"/>柁<anchor xml:id="app0810090710e"/>不干、舟艫〈 <anchor xml:id="app0810090711"
                 />能<anchor xml:id="app0810090711e"/>〉至 <anchor xml:id="app0810090712"/>〈留〉<anchor xml:id="app0810090712e"
               />極、大海原〈尓〉舟満都 <anchor xml:id="app0810090713"/>都<anchor xml:id="app0810090713e"
@@ -3552,7 +3552,7 @@
               <lem wit="#土本 #永本 #右本">登</lem>
               <rdg wit="#九本">止</rdg>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00019.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00019.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v8_en.xml#item08100909 engishiki_v8_ja.xml#item08100909" xml:id="item08100909">
                 山〈<anchor xml:id="app0810090901"/>能<anchor xml:id="app0810090901e"/>〉口坐皇神等〈 <anchor xml:id="app0810090902"
                 />能<anchor xml:id="app0810090902e"/>〉前〈尓〉白〈久〉、飛鳥・石 <anchor xml:id="app0810090903"/>寸<anchor
@@ -3685,7 +3685,7 @@
                 辞別、忌部〈<anchor xml:id="app0810091101"/>能<anchor xml:id="app0810091101e"/>〉弱肩〈尓〉 <anchor xml:id="app0810091102"
                 />太<anchor xml:id="app0810091102e"/>襁取挂〈 <anchor xml:id="app0810091103"/>弖<anchor xml:id="app0810091103e"
               />〉、持由麻波利仕奉〈礼留〉幣帛〈乎〉、神主・祝部等受賜〈弖〉、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00020.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00020.tif/full/full/0/default.jpg"/>
               事不過捧持奉〈 <anchor xml:id="app0810091104"/>登<anchor xml:id="app0810091104e"/>〉宣、 </p>
             <app from="#app0810091101" to="#app0810091101e">
               <lem wit="#土本 #永本 #右本">能</lem>
@@ -3730,7 +3730,7 @@
               />〉瑞之 <anchor xml:id="app0810100122"/>御<anchor xml:id="app0810100122e"/>殿、〈古語云阿良可、〉汝屋船命〈尓〉天津奇護言〈乎〉〈古語云久須志伊波比
                 <anchor xml:id="app0810100123"/>許登<anchor xml:id="app0810100123e"/>、〉以〈 <anchor xml:id="app0810100124"
                 />弖<anchor xml:id="app0810100124e"/>〉、言寿鎮白〈久〉、此 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00021.tif/full/full/0/default.jpg"/> 〈
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00021.tif/full/full/0/default.jpg"/> 〈
                 <anchor xml:id="app0810100125"/>能<anchor xml:id="app0810100125e"/>〉敷坐大宮地、底津磐根〈 <anchor xml:id="app0810100126"
                 />能<anchor xml:id="app0810100126e"/>〉極〈美〉、下津綱根〈古語番 <anchor xml:id="app0810100127"/>縄<anchor
                 xml:id="app0810100127e"/>之類、謂之綱根、〉波府虫〈 <anchor xml:id="app0810100128"/>能<anchor xml:id="app0810100128e"/>〉
@@ -4039,7 +4039,7 @@
             <p ana="項" corresp="engishiki_v8_en.xml#item08101002 engishiki_v8_ja.xml#item08101002" xml:id="item08101002">
                 詞別<anchor xml:id="app0810100201"/>白<anchor xml:id="app0810100201e"/>〈久〉、大宮売命〈 <anchor xml:id="app0810100202"
                 />登<anchor xml:id="app0810100202e"/>〉御名〈乎〉申事〈波〉、皇 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00022.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00022.tif/full/full/0/default.jpg"/>
               御孫命〈乃〉同殿〈 <anchor xml:id="app0810100203"/>能<anchor xml:id="app0810100203e"/>〉裏〈尓〉塞坐〈弖〉、参入罷出 <anchor
                 xml:id="app0810100204"/>人<anchor xml:id="app0810100204e"/>〈 <anchor xml:id="app0810100205"/>能<anchor
                 xml:id="app0810100205e"/>〉選〈比〉所知〈 <anchor xml:id="app0810100206"/>志<anchor xml:id="app0810100206e"
@@ -4174,7 +4174,7 @@
                 xml:id="app0810110110"/>却<anchor xml:id="app0810110110e"/>、言排坐〈弖〉、朝〈波〉開門、夕〈波〉閉門〈弖〉、参入罷出人名〈乎〉 <anchor
                 xml:id="app0810110111"/>問<anchor xml:id="app0810110111e"/>所知〈 <anchor xml:id="app0810110112"/>志<anchor
                 xml:id="app0810110112e"/>〉、咎過在〈乎波〉、神直〈備〉大直〈備尓〉見直 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00023.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00023.tif/full/full/0/default.jpg"/>
               聞直坐〈弖〉、平〈 <anchor xml:id="app0810110113"/>良気<anchor xml:id="app0810110113e"/>久〉 <anchor xml:id="app0810110114"
                 />安〈良気久〉<anchor xml:id="app0810110114e"/>令奉仕賜故〈尓〉、豊磐牖命・櫛磐牖命〈 <anchor xml:id="app0810110115"/>登<anchor
                 xml:id="app0810110115e"/>〉御名〈乎〉称辞竟奉〈久<anchor xml:id="app0810110116"/>登<anchor xml:id="app0810110116e"
@@ -4307,7 +4307,7 @@
               />、天降依〈左 <anchor xml:id="app0810120315"/>志<anchor xml:id="app0810120315e"/>〉奉〈支〉、如此〈 <anchor
                 xml:id="app0810120316"/>久<anchor xml:id="app0810120316e"/>〉依〈左 <anchor xml:id="app0810120317"/>志<anchor
                 xml:id="app0810120317e"/>〉奉〈 <anchor xml:id="app0810120318"/>志<anchor xml:id="app0810120318e"/>〉四方之国中 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00024.tif/full/full/0/default.jpg"/> 〈
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00024.tif/full/full/0/default.jpg"/> 〈
                 <anchor xml:id="app0810120319"/>登<anchor xml:id="app0810120319e"/>〉、大倭日高見之国〈乎〉安国〈 <anchor
                 xml:id="app0810120320"/>止<anchor xml:id="app0810120320e"/>〉定奉〈弖〉、下津磐根〈尓〉宮柱 <anchor xml:id="app0810120321"
                 />太<anchor xml:id="app0810120321e"/>敷立、高天原〈尓〉千木高知〈弖〉、皇御孫之命〈乃〉美頭〈乃〉御舎仕奉〈弖〉、天之御蔭・日之御蔭〈止〉隠坐〈弖〉、安国〈止〉平〈 <anchor
@@ -4324,7 +4324,7 @@
                 />〈曾<anchor xml:id="app0810120333e"/>乎〉本苅断、末苅切〈弖〉、八針〈尓〉取辟〈弖〉、天津祝詞〈乃〉太祝詞事〈乎〉宣〈礼〉、如此〈久 <anchor
                 xml:id="app0810120334"/>乃良<anchor xml:id="app0810120334e"
               />波〉、天津神〈波〉天磐門〈乎〉押披〈弖〉、天之八重雲〈乎〉伊頭〈乃〉千別〈尓〉千別〈弖〉所聞食〈武〉、国津神〈波〉高山之 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00025.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00025.tif/full/full/0/default.jpg"/>
               末・短 <anchor xml:id="app0810120335"/>山<anchor xml:id="app0810120335e"/>末〈尓〉上坐〈弖〉、高山之伊 <anchor
                 xml:id="app0810120336"/>恵<anchor xml:id="app0810120336e"/>理・短山之伊恵理〈乎〉撥別〈弖〉所聞食〈武〉、如此所聞食〈弖波〉、 <anchor
                 xml:id="app0810120337"/>皇御孫之命〈乃〉朝 <anchor xml:id="app0810120338"/>庭<anchor xml:id="app0810120338e"
@@ -4345,7 +4345,7 @@
                 <anchor xml:id="app0810120355"/>比<anchor xml:id="app0810120355e"/>失〈弖 <anchor xml:id="app0810120356"
                 />牟<anchor xml:id="app0810120356e"/>〉、如此〈久〉失〈弖波〉、 <anchor xml:id="app0810120357"/>天皇〈我〉<anchor
                 xml:id="app0810120357e"/>朝庭〈尓〉仕奉〈留〉官 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00026.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00026.tif/full/full/0/default.jpg"/>
               <anchor xml:id="app0810120358"/>官<anchor xml:id="app0810120358e"/>人等〈乎〉始〈弖〉、天下四 <anchor xml:id="app0810120359"
                 />方<anchor xml:id="app0810120359e"/>〈尓波〉、自今日始〈弖〉、罪〈止〉云〈 <anchor xml:id="app0810120360"/>布<anchor
                 xml:id="app0810120360e"/>〉 <anchor xml:id="app0810120361"/>罪<anchor xml:id="app0810120361e"
@@ -4714,7 +4714,7 @@
               />〉水穂国〈乎〉、安国〈止〉平〈久〉所知食〈止〉、天下所寄奉〈 <anchor xml:id="app0810140103"/>志<anchor xml:id="app0810140103e"
               />〉時〈尓〉、事寄奉〈志〉天都詞太詞事〈乎〉以〈弖〉申〈久〉、神伊佐奈伎・伊佐奈美〈 <anchor xml:id="app0810140104"/>能<anchor xml:id="app0810140104e"
               />〉命、妹妋二柱嫁継 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00027.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00027.tif/full/full/0/default.jpg"/>
               給〈弖〉、国〈 <anchor xml:id="app0810140105"/>能<anchor xml:id="app0810140105e"/>〉八十国・島〈 <anchor
                 xml:id="app0810140106"/>能<anchor xml:id="app0810140106e"/>〉八十島〈乎〉生給〈比〉、八百万神等〈乎〉生給〈比弖〉、麻奈弟子〈尓〉 <anchor
                 xml:id="app0810140107"/>火<anchor xml:id="app0810140107e"/>結神生給〈弖〉、美保止被焼〈弖〉、石隠坐〈弖〉、夜七 <anchor
@@ -4734,7 +4734,7 @@
                 />能<anchor xml:id="app0810140122e"/>〉朝 <anchor xml:id="app0810140123"/>庭<anchor xml:id="app0810140123e"
               />〈尓〉御心一速〈比〉給〈波 <anchor xml:id="app0810140124"/>志<anchor xml:id="app0810140124e"/>止〉為〈弖〉、進物〈波〉明妙・照妙・和 <anchor
                 xml:id="app0810140125"/>妙<anchor xml:id="app0810140125e"/>・荒妙、五色物〈乎〉備奉〈弖〉、青海原〈尓〉住物者、鰭広物・鰭狭物、奥津海菜・辺津海菜 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00028.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00028.tif/full/full/0/default.jpg"/>
               〈尓〉至〈万弖尓〉、御酒者 <anchor xml:id="app0810140126"/>𤭖<anchor xml:id="app0810140126e"/>辺高知、 <anchor
                 xml:id="app0810140127"/>𤭖<anchor xml:id="app0810140127e"/>腹満双〈弖〉、和稲・荒稲〈尓〉至〈万弖尓〉、如横山置高成〈弖〉、天津祝詞〈 <anchor
                 xml:id="app0810140128"/>能<anchor xml:id="app0810140128e"/>〉 <anchor xml:id="app0810140129"/>太<anchor
@@ -4892,7 +4892,7 @@
                 xml:id="app0810150112"/>之<anchor xml:id="app0810150112e"/>幣帛〈乎〉、平〈 <anchor xml:id="app0810150113"/>気<anchor
                 xml:id="app0810150113e"/>久〉聞食〈弖〉、八衢〈尓〉湯 <anchor xml:id="app0810150114"/>津<anchor xml:id="app0810150114e"
               />磐村之如〈久〉塞坐〈弖〉、皇御孫命〈乎〉堅磐〈尓〉常磐〈尓〉斎奉、 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00029.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00029.tif/full/full/0/default.jpg"/>
               茂御世〈尓〉幸〈閉〉奉給〈止〉申、又親王 <anchor xml:id="app0810150115"/>等<anchor xml:id="app0810150115e"/>・ <anchor
                 xml:id="app0810150116"/>王等<anchor xml:id="app0810150116e"/>・臣等・百官人等、天下公民〈尓〉至〈万弖尓〉、平〈久〉斎給〈部止〉、神官、天津祝詞〈乃〉
                 <anchor xml:id="app0810150117"/>太<anchor xml:id="app0810150117e"/>祝詞事〈乎〉以〈弖〉、称辞竟奉〈止〉申、</p>
@@ -5050,7 +5050,7 @@
             <p ana="項" corresp="engishiki_v8_en.xml#item08101603 engishiki_v8_ja.xml#item08101603" xml:id="item08101603">
                 事別、忌部〈<anchor xml:id="app0810160301"/>能<anchor xml:id="app0810160301e"/>〉弱肩〈尓〉 <anchor xml:id="app0810160302"
                 />太<anchor xml:id="app0810160302e"/>襁取挂〈弖〉、持由 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00030.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00030.tif/full/full/0/default.jpg"/>
               麻波利仕奉〈礼留〉幣帛〈乎〉、神主・祝部等請〈弖〉、事不落捧持〈弖〉奉〈 <anchor xml:id="app0810160303"/>登<anchor xml:id="app0810160303e"/>〉宣、 </p>
             <app from="#app0810160301" to="#app0810160301e">
               <lem wit="#土本 #永本">能</lem>
@@ -5163,7 +5163,7 @@
               <note>其　訳注本・粕谷本は「某」を採用する。</note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00031.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00031.tif/full/full/0/default.jpg"/>
           <div ana="祝詞" corresp="engishiki_v8_en.xml#article081018 engishiki_v8_ja.xml#article081018" n="8.18" type="条"
             xml:id="article081018">
             <head ana="神宮祈年月次祭"/>
@@ -5232,7 +5232,7 @@
                 />太<anchor xml:id="app0810200104e"/>神〈乃〉大前〈尓〉申〈久〉、服織・麻 <anchor xml:id="app0810200105"/>績<anchor
                 xml:id="app0810200105e"/>〈乃〉人等〈乃〉常〈 <anchor xml:id="app0810200106"/>毛<anchor xml:id="app0810200106e"
               />〉奉仕〈留〉和妙・荒妙〈乃〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00032.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00032.tif/full/full/0/default.jpg"/>
               織〈乃〉御衣〈乎〉進事〈乎〉、申給〈止〉申、荒祭宮〈尓毛〉如是申〈 <anchor xml:id="app0810200107"/>天<anchor xml:id="app0810200107e"
               />〉進〈止〉宣、〈禰宜・内人称唯、〉</p>
             <app from="#app0810200101" to="#app0810200101e">
@@ -5320,7 +5320,7 @@
                 xml:id="app0810210210"/>登<anchor xml:id="app0810210210e"/>〈 <anchor xml:id="app0810210211"/>尓<anchor
                 xml:id="app0810210211e"/>〉称申 <anchor xml:id="app0810210212"/>事<anchor xml:id="app0810210212e"
               />〈乎〉、神主部・物忌等、諸聞食〈止〉宣、〈神主部共称唯、〉荒祭宮・月読宮〈尓毛〉如是〈久〉申進〈止〉宣、〈神主部亦 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00033.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00033.tif/full/full/0/default.jpg"/>
               称唯、〉 </p>
             <app from="#app0810210201" to="#app0810210201e">
               <lem wit="#土本 #永本 #右本 #九本">命</lem>
@@ -5510,7 +5510,7 @@
               同神嘗祭<lb/>度会〈乃〉宇治〈乃〉五十鈴〈乃〉川上〈尓〉大宮柱 <anchor xml:id="app0810240101"/>太<anchor xml:id="app0810240101e"/>敷立〈 <anchor
                 xml:id="app0810240102"/>天<anchor xml:id="app0810240102e"/>〉、高天原〈尓〉比木高知〈 <anchor xml:id="app0810240103"
                 />天<anchor xml:id="app0810240103e"/>〉、称辞竟奉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00034.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00034.tif/full/full/0/default.jpg"/>
               〈留〉天照坐皇 <anchor xml:id="app0810240104"/>太<anchor xml:id="app0810240104e"/>神〈乃〉大前〈尓〉、申進〈留〉天津祝詞〈乃〉太祝詞〈 <anchor
                 xml:id="app0810240105"/>乎<anchor xml:id="app0810240105e"/>〉、神主部・物忌等、諸聞食〈止〉宣、〈 <anchor xml:id="app0810240106"
                 />禰<anchor xml:id="app0810240106e"/>宜・内人等共称唯、〉</p>
@@ -5603,7 +5603,7 @@
                 斎内親王<anchor xml:id="app0810250101"/>奉<anchor xml:id="app0810250101e"/>入時 <lb/>進神嘗幣詞申畢、次即申云、辞別〈弖〉申給〈 <anchor
                 xml:id="app0810250102"/>久<anchor xml:id="app0810250102e"/>〉、今進〈 <anchor xml:id="app0810250103"/>流<anchor
                 xml:id="app0810250103e"/>〉斎 <anchor xml:id="app0810250104"/>内<anchor xml:id="app0810250104e"/>親王〈波〉、依恒例〈弖〉、三
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00035.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00035.tif/full/full/0/default.jpg"/>
               <anchor xml:id="app0810250105"/>年<anchor xml:id="app0810250105e"/>斎〈比〉清〈麻波 <anchor xml:id="app0810250106"
                 />理<anchor xml:id="app0810250106e"/>弖〉、御杖代〈止〉定〈弖〉進給事〈波〉、皇御孫之尊〈乎〉天地日月〈止〉共〈尓〉 <anchor xml:id="app0810250107"
                 />堅<anchor xml:id="app0810250107e"/>磐〈尓〉、平〈 <anchor xml:id="app0810250108"/>気<anchor xml:id="app0810250108e"
@@ -5717,7 +5717,7 @@
               />〉命以〈弖〉、天之高市〈尓〉八百万神等〈乎〉、神集集給〈比〉、神議議給〈弖〉、我皇御孫之尊〈波〉豊葦原〈 <anchor xml:id="app0810270108"/>能<anchor
                 xml:id="app0810270108e"/>〉水穂之国〈乎〉安国〈止〉平〈 <anchor xml:id="app0810270109"/>気<anchor xml:id="app0810270109e"
               />久〉所知食〈止〉、天之磐座放〈弖〉、天之八重雲〈乎〉伊頭之千別〈支尓〉千別 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00036.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00036.tif/full/full/0/default.jpg"/>
               〈弖〉、天降所寄奉〈 <anchor xml:id="app0810270110"/>志<anchor xml:id="app0810270110e"/>〉時〈尓〉、誰神〈乎〉先 <anchor
                 xml:id="app0810270111"/>遣<anchor xml:id="app0810270111e"/>〈波〉、水穂国〈 <anchor xml:id="app0810270112"/>能<anchor
                 xml:id="app0810270112e"/>〉荒振神等〈乎〉神攘攘平〈 <anchor xml:id="app0810270113"/>気<anchor xml:id="app0810270113e"
@@ -5735,7 +5735,7 @@
                 <anchor xml:id="app0810270126"/>気<anchor xml:id="app0810270126e"/>久〉所知食〈 <anchor xml:id="app0810270127"
                 />武<anchor xml:id="app0810270127e"/>〉皇御孫之尊〈 <anchor xml:id="app0810270128"/>能<anchor xml:id="app0810270128e"
               />〉天御舎之内〈 <anchor xml:id="app0810270129"/>尓<anchor xml:id="app0810270129e"/>〉坐〈須〉皇 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00037.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00037.tif/full/full/0/default.jpg"/>
               神等〈波〉、荒備給〈比〉健備 <anchor xml:id="app0810270130"/>給<anchor xml:id="app0810270130e"/>事無〈 <anchor
                 xml:id="app0810270131"/>志<anchor xml:id="app0810270131e"/>弖〉、高天之原〈尓〉始〈 <anchor xml:id="app0810270132"
                 />志<anchor xml:id="app0810270132e"/>〉事〈乎〉神〈奈 <anchor xml:id="app0810270133"/>我<anchor xml:id="app0810270133e"
@@ -5973,7 +5973,7 @@
             <head ana="遣唐使"/>
             <p ana="項" corresp="engishiki_v8_en.xml#item08102801 engishiki_v8_ja.xml#item08102801" xml:id="item08102801">
               遣唐使時奉幣 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00038.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00038.tif/full/full/0/default.jpg"/>
               <lb/>皇御孫尊〈 <anchor xml:id="app0810280101"/>能<anchor xml:id="app0810280101e"
                 />〉御命以〈弖〉、住吉〈尓〉辞竟奉〈留〉皇神等前〈尓〉申賜〈久〉、大唐〈尓〉使遣〈佐牟止〉為〈尓〉、依船居無〈弖〉、<placeName corresp="#播磨国">播磨国</placeName>〈与
                 <anchor xml:id="app0810280102"/>理<anchor xml:id="app0810280102e"/>〉船乗〈止〉為〈弖〉、使者遣〈 <anchor
@@ -6025,7 +6025,7 @@
                 xml:id="app0810290112"/>能<anchor xml:id="app0810290112e"/>〉日真名子加夫呂伎熊野大神、櫛御気野命、国作坐〈 <anchor
                 xml:id="app0810290113"/>志<anchor xml:id="app0810290113e"/>〉大穴持命、二柱神〈乎〉始〈 <anchor xml:id="app0810290114"
                 />天<anchor xml:id="app0810290114e"/>〉、百八十六社坐皇神等〈乎〉、某 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00039.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00039.tif/full/full/0/default.jpg"/>
               甲〈我〉弱肩〈尓〉 <anchor xml:id="app0810290115"/>太<anchor xml:id="app0810290115e"/>襷挂〈 <anchor xml:id="app0810290116"
                 />天<anchor xml:id="app0810290116e"/>〉、伊都幣〈 <anchor xml:id="app0810290117"/>能<anchor xml:id="app0810290117e"
               />〉緒結、天〈乃〉美賀秘冠〈利 <anchor xml:id="app0810290118"/>天<anchor xml:id="app0810290118e"/>〉、伊豆〈 <anchor
@@ -6202,7 +6202,7 @@
                 xml:id="app0810290214e"/>〉、天降遣〈 <anchor xml:id="app0810290215"/>天<anchor xml:id="app0810290215e"
               />〉、荒〈布留〉神等〈乎〉撥平〈 <anchor xml:id="app0810290216"/>気<anchor xml:id="app0810290216e"/>〉、国作〈之〉大神〈乎毛〉媚鎮〈 <anchor
                 xml:id="app0810290217"/>天<anchor xml:id="app0810290217e"/>〉、大八島国現事・顕 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00040.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00040.tif/full/full/0/default.jpg"/>
               事令事避〈支〉、乃大穴持命〈乃〉申給〈久〉、皇御孫命〈乃〉静坐〈牟〉大倭国申〈 <anchor xml:id="app0810290218"/>天<anchor xml:id="app0810290218e"
               />〉、己命和魂〈乎〉八 <anchor xml:id="app0810290219"/>咫<anchor xml:id="app0810290219e"/>鏡〈尓〉取託〈 <anchor
                 xml:id="app0810290220"/>天<anchor xml:id="app0810290220e"/>〉、倭大物主櫛 <anchor xml:id="app0810290221"/>𤭖<anchor
@@ -6418,7 +6418,7 @@
                 白玉〈<anchor xml:id="app0810290301"/>能<anchor xml:id="app0810290301e"/>〉大御白髪坐、赤玉〈 <anchor
                 xml:id="app0810290302"/>能<anchor xml:id="app0810290302e"/>〉御阿加良毗坐、青玉〈 <anchor xml:id="app0810290303"
                 />能<anchor xml:id="app0810290303e"/>〉水 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00041.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00041.tif/full/full/0/default.jpg"/>
               江玉〈 <anchor xml:id="app0810290304"/>能<anchor xml:id="app0810290304e"/>〉行相〈尓〉、明御神〈 <anchor
                 xml:id="app0810290305"/>登<anchor xml:id="app0810290305e"/>〉大八島国所知食天皇命〈 <anchor xml:id="app0810290306"
                 />能<anchor xml:id="app0810290306e"/>〉手長大御世〈乎〉、御横刀 <anchor xml:id="app0810290307"/>広<anchor
@@ -6647,7 +6647,7 @@
             </app>
           </div>
         </div>
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00042.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00042.tif/full/full/0/default.jpg"/>
         <div type="尾題" xml:id="bidai08">
           <p xml:id="bidai0801"> 延喜式巻第八</p>
         </div>
@@ -6720,133 +6720,133 @@
   </text>
   <facsimile>
     <surface xml:id="page4016" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4016">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4017" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4017">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4018" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4018">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4019" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4019">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4020" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4020">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4021" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4021">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4022" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4022">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4023" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4023">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4024" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4024">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4025" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4025">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4026" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4026">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4027" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4027">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4028" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4028">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4029" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4029">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4030" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4030">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4031" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4031">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4032" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4032">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4033" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4033">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4034" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4034">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4035" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4035">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4036" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4036">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4037" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4037">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4038" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4038">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4039" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4039">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4040" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4040">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4041" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4041">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4042" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4042">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4043" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4043">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4044" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4044">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4045" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4045">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4046" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4046">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4047" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4047">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4048" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4048">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4049" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4049">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4050" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4050">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4051" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4051">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00036.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4052" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4052">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00037.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00037.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4053" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4053">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00038.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00038.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4054" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4054">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00039.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00039.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4055" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4055">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00040.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00040.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4056" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4056">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00041.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00041.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4057" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4057">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00042.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00042.tif/full/full/0/default.jpg"/>
     </surface>
     <surface xml:id="page4058" source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8/page4058">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-8%2F00043.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-8/00043.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>

--- a/TEI編集用/engishiki_v9.xml
+++ b/TEI編集用/engishiki_v9.xml
@@ -1368,7 +1368,7 @@
   <text>
     <body>
       <div ana="神名上" n="9" type="巻" xml:id="volume9">
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00002.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00002.tif/full/full/0/default.jpg"/>
         <div type="首題" xml:id="shudai09">
           <p xml:id="shudai0901"><anchor xml:id="app0966660101"/> 延喜式巻第九 <anchor xml:id="app0966660101e"/> 〈 <orgName
               corresp="#神祇官"> 神祇 </orgName>
@@ -1404,7 +1404,7 @@
               <lb/>
               <seg rendition="#indent"> 一百八十八座〈並預祈年国幣、〉 </seg>
               <lb/> 小二千六百卌座 <lb/>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00003.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00003.tif/full/full/0/default.jpg"/>
               <seg rendition="#indent"> 四百卅三座〈並預祈年案下官幣、〉 </seg>
               <lb/>
               <seg rendition="#indent"><anchor xml:id="app0910010102"/> 二千二百七座〈並預祈年国幣、〉 <anchor xml:id="app0910010102e"/>
@@ -1509,7 +1509,7 @@
               </table>
               <lb/>
               <orgName corresp="#宮内省"> 宮内省 </orgName> 坐神三座〈並名神大、月次、新嘗、〉 <pb
-                facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00004.tif/full/full/0/default.jpg"/>
+                facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00004.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app0910020121"/><anchor xml:id="app0910020121e"/><anchor
@@ -1789,7 +1789,7 @@
             <p ana="項" corresp="engishiki_v9_en.xml#item09100501 engishiki_v9_ja.xml#item09100501" xml:id="item09100501"
                 ><placeName corresp="#山城国"> 山城国 </placeName> 一百廿二座 <lb/>
               <seg rendition="#indent"> 大五十三座〈並月次・新嘗、就中十一座預相嘗祭、〉 <pb
-                  facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00005.tif/full/full/0/default.jpg"/>
+                  facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00005.tif/full/full/0/default.jpg"/>
                 小六十 <anchor xml:id="app0910050101"/> 九 <anchor xml:id="app0910050101e"/> 座〈 <anchor xml:id="app0910050102"/>
                 並官幣 <anchor xml:id="app0910050102e"/> 、〉 </seg>
             </p>
@@ -1931,7 +1931,7 @@
                     〈並名神大、月次、新嘗、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00006.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00006.tif/full/full/0/default.jpg"
                       /><anchor xml:id="app0910050312"/> 天津石門別稚姫神社 <anchor xml:id="app0910050312e"/> 〈 <anchor
                       xml:id="app0910050313"/> 名神大、月次、新嘗 <anchor xml:id="app0910050313e"/> 、〉 </cell>
                 </row>
@@ -2234,7 +2234,7 @@
               <rdg wit="#吉本"> 三座 </rdg>
               <note> 三社　訳注本は藤波本校注に従い「社三座」を採用する。永本・剛本・土本・京博本「三社」、吉本「三座」。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00007.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00007.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09100506 engishiki_v9_ja.xml#item09100506" xml:id="item09100506">
               <seg rendition="#indent"> 宇治郡十座〈大五座、小五座、〉 </seg>
               <table>
@@ -2401,7 +2401,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 天神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00008.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00008.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 地祇神社 </cell>
                   <cell rendition="#width50"/>
@@ -2545,7 +2545,7 @@
                     <anchor xml:id="app0910060208e"/> 四座〈並名神大、月次、新嘗、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00009.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00009.tif/full/full/0/default.jpg"
                     /> 赤穂神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 島田神社 </cell>
@@ -2754,7 +2754,7 @@
               <note> 吉本補入「寺〈官〉」 </note>
               <note> 寺坐　永本は左傍書「官与」を「寺」字下に補入。吉本は本文「与」とし、その上に「寺〈官〉」を補入。いずれも九本・剛本・京博本・土本により本文とはみなさず。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00010.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00010.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09100605 engishiki_v9_ja.xml#item09100605" xml:id="item09100605">
               <seg rendition="#indent"> 広瀬郡五座〈大一座、小四座、〉 </seg>
               <table>
@@ -2964,7 +2964,7 @@
                   <cell rendition="#width300"> 金村神社〈大、月次、新嘗、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00011.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00011.tif/full/full/0/default.jpg"
                     /> 葛木御県神社〈 <anchor xml:id="app0910060704"/> 大、月次、新嘗 <anchor xml:id="app0910060704e"/> 、〉 </cell>
                 </row>
                 <row>
@@ -3141,7 +3141,7 @@
                   <cell rendition="#width300"> 高桙神社〈 <anchor xml:id="app0910061007"/> 鍬 <anchor xml:id="app0910061007e"/> 、〉
                   </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00012.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00012.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 川上鹿塩神社 <anchor xml:id="app0910061008"/> 〈鍬、〉 <anchor xml:id="app0910061008e"/>
                   </cell>
@@ -3367,7 +3367,7 @@
                   <cell rendition="#width300"> 殖栗神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00013.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00013.tif/full/full/0/default.jpg"
                     /> 水口神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 桑内神社二座〈鍬、靫、〉 </cell>
@@ -3588,7 +3588,7 @@
             </app>
             <p ana="項" corresp="engishiki_v9_en.xml#item09100614 engishiki_v9_ja.xml#item09100614" xml:id="item09100614">
               <seg rendition="#indent"><anchor xml:id="app0910061401"/><anchor xml:id="app0910061401e"/> 高市郡五十四座〈大卅三座、小廿一座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00014.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00014.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 高市御 <anchor xml:id="app0910061402"/> 県 <anchor xml:id="app0910061402e"/> 坐鴨事代
@@ -3684,7 +3684,7 @@
                       xml:id="app0910061421"/> 久 <anchor xml:id="app0910061421e"/> 米御県神社三座 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00015.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00015.tif/full/full/0/default.jpg"
                       /><anchor xml:id="app0910061422"/> 気吹雷響雷吉野大国栖御魂神社 <anchor xml:id="app0910061422e"/> 二座〈並名神大、月次、新嘗、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"/>
@@ -3951,7 +3951,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 祝田神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00016.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00016.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app0910061605"/><anchor xml:id="app0910061605e"/> 石上市神社 </cell>
                   <cell rendition="#width50"/>
@@ -4100,7 +4100,7 @@
                   <cell rendition="#width300"> 宿奈川田神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00017.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00017.tif/full/full/0/default.jpg"
                     /> 金山孫神社 </cell>
                 </row>
                 <row>
@@ -4247,7 +4247,7 @@
                   <cell rendition="#width300"> 御机神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00018.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00018.tif/full/full/0/default.jpg"
                     /> 高宮神社〈大、月次、新嘗、〉 </cell>
                 </row>
                 <row>
@@ -4379,7 +4379,7 @@
               <rdg wit="#土本 #京博本"> 仲 </rdg>
               <note> 中　土本・京博本「仲」、永本・九本・剛本・吉本「中」。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00019.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00019.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09100712 engishiki_v9_ja.xml#item09100712" xml:id="item09100712">
               <seg rendition="#indent"> 渋川郡六座〈並小、〉 </seg>
               <table>
@@ -4536,7 +4536,7 @@
                 ><placeName corresp="#和泉国"> 和泉国 </placeName> 六十二座 <lb/>
               <seg rendition="#indent"> 大一 <anchor xml:id="app0910080101"/> 座 <anchor xml:id="app0910080101e"/>
               </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00020.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00020.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"> 小六十一 <anchor xml:id="app0910080102"/> 座 <anchor xml:id="app0910080102e"/>
               </seg>
@@ -4690,7 +4690,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 粟神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00021.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00021.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 曾 <anchor xml:id="app0910080303"/> 禰 <anchor xml:id="app0910080303e"/> 神社 </cell>
                   <cell rendition="#width50"/>
@@ -4805,7 +4805,7 @@
             </app>
             <p ana="項" corresp="engishiki_v9_en.xml#item09100902 engishiki_v9_ja.xml#item09100902" xml:id="item09100902">
               <seg rendition="#indent"> 住吉郡廿二座〈大十座、小十二座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00022.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00022.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app0910090201"/> 住吉坐神社 <anchor xml:id="app0910090201e"/>
@@ -4946,7 +4946,7 @@
             <p ana="項" corresp="engishiki_v9_en.xml#item09100906 engishiki_v9_ja.xml#item09100906" xml:id="item09100906">
               <seg rendition="#indent"> 島下 <anchor xml:id="app0910090601"/> 郡 <anchor xml:id="app0910090601e"/>
                 十七座〈大五座、小十二座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00023.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00023.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 新屋坐天照御魂神社三座〈並名神大、月次、新嘗、就中天照御魂神一座預相嘗 <anchor xml:id="app0910090602"/> 祭 <anchor
@@ -5094,7 +5094,7 @@
               <rdg wit="#土本"/>
               <note> 鍬、靫　土本無し、永本・九本・剛本・吉本・京博本あり。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00024.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00024.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09100910 engishiki_v9_ja.xml#item09100910" xml:id="item09100910">
               <seg rendition="#indent"> 菟原郡三座〈並小、〉 </seg>
               <table>
@@ -5213,7 +5213,7 @@
                   <cell rendition="#width300"> 宇都可神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00025.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00025.tif/full/full/0/default.jpg"
                     /> 波 <anchor xml:id="app0910110202"/> 太 <anchor xml:id="app0910110202e"/> 伎神社 </cell>
                 </row>
                 <row>
@@ -5354,7 +5354,7 @@
                 ><placeName corresp="#伊勢国"> 伊勢国 </placeName> 二百五十三座 <lb/>
               <seg rendition="#indent"> 大十八座〈就中十四座預月次・新嘗等 <anchor xml:id="app0910120101"/> 祭 <anchor xml:id="app0910120101e"
                 /> 、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00026.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00026.tif/full/full/0/default.jpg"/>
               <lb/>
               <seg rendition="#indent"> 小二百卅五座 </seg>
             </p>
@@ -5444,7 +5444,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 粟皇子神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00027.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00027.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 久久都比売神社 </cell>
                   <cell rendition="#width50"/>
@@ -5624,7 +5624,7 @@
                   <cell rendition="#width300"> 奈 <anchor xml:id="app0910120303"/> 奈 <anchor xml:id="app0910120303e"/> 美神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00028.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00028.tif/full/full/0/default.jpg"
                     /> 魚海神社二座 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 林神社 </cell>
@@ -5767,7 +5767,7 @@
               <note place="傍"> 剛本傍訓「ウシ」 </note>
               <note> 牛庭　土本「牛遅」、永本・九本・吉本・京博本「牛庭」、剛本「生庭」（ただし傍訓「ウシ」）。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00029.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00029.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101204 engishiki_v9_ja.xml#item09101204" xml:id="item09101204">
               <table rendition="#indent">
                 <row>
@@ -5893,7 +5893,7 @@
                   <cell rendition="#width300"> 小丹神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00030.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00030.tif/full/full/0/default.jpg"
                     /> 美濃夜神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 阿由太神社 </cell>
@@ -6001,7 +6001,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 江神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00031.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00031.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 布気神社 </cell>
                   <cell rendition="#width50"/>
@@ -6136,7 +6136,7 @@
               <note place="傍"> 吉本傍書「江」 </note>
               <note> 深　土本・京博本、永本左傍書、吉本傍書および訳注本「江」。永本・九本・剛本・吉本「深」。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00032.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00032.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101212 engishiki_v9_ja.xml#item09101212" xml:id="item09101212">
               <seg rendition="#indent"> 朝明郡廿四座〈並小、〉 </seg>
               <table>
@@ -6251,7 +6251,7 @@
                   <cell rendition="#width300"> 大谷神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00033.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00033.tif/full/full/0/default.jpg"
                     /> 賀毛神社 </cell>
                 </row>
                 <row>
@@ -6373,7 +6373,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 由乃伎神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00034.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00034.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 伊久波神社 </cell>
                   <cell rendition="#width50"/>
@@ -6539,7 +6539,7 @@
             </app>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101404 engishiki_v9_ja.xml#item09101404" xml:id="item09101404">
               <seg rendition="#indent"> 葉栗郡十座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00035.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00035.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app0910140401"/> 穴太部神社 <anchor xml:id="app0910140401e"/>
@@ -6662,7 +6662,7 @@
             </app>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101406 engishiki_v9_ja.xml#item09101406" xml:id="item09101406">
               <seg rendition="#indent"> 春部郡十二座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00036.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00036.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 非多神社 </cell>
@@ -6779,7 +6779,7 @@
             </app>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101408 engishiki_v9_ja.xml#item09101408" xml:id="item09101408">
               <seg rendition="#indent"> 愛智郡十七座〈大四座、小十三座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00037.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00037.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 日置神社 </cell>
@@ -6907,7 +6907,7 @@
                 </row>
               </table>
             </p>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00038.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00038.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101503 engishiki_v9_ja.xml#item09101503" xml:id="item09101503">
               <seg rendition="#indent"> 額田郡二座〈並小、〉 </seg>
               <table>
@@ -7030,7 +7030,7 @@
             </app>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101602 engishiki_v9_ja.xml#item09101602" xml:id="item09101602">
               <seg rendition="#indent"> 浜名郡五座〈大一座、小四座、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00039.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00039.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app0910160201"/> 弥 <anchor xml:id="app0910160201e"/> 和山神社 </cell>
@@ -7152,7 +7152,7 @@
             </p>
             <p ana="項" corresp="engishiki_v9_en.xml#item09101607 engishiki_v9_ja.xml#item09101607" xml:id="item09101607">
               <seg rendition="#indent"> 長上郡五座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00040.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00040.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 大歳神社 </cell>
@@ -7254,7 +7254,7 @@
                   <cell rendition="#width300"> 己等乃麻知神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00041.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00041.tif/full/full/0/default.jpg"
                     /> 阿波波神社 </cell>
                 </row>
                 <row>
@@ -7367,7 +7367,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 白沢神社 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00042.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00042.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 大歳御祖神社 </cell>
                   <cell rendition="#width50"/>
@@ -7476,7 +7476,7 @@
                   <cell rendition="#width300"> 波夜志命神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00043.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00043.tif/full/full/0/default.jpg"
                     /> 優波夷命神社 </cell>
                 </row>
                 <row>
@@ -7651,7 +7651,7 @@
                   <cell rendition="#width300"> 倭文神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00044.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00044.tif/full/full/0/default.jpg"
                     /> 高椅神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 長浜神社 </cell>
@@ -7779,7 +7779,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"> 佐波神社二座 </cell>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00045.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00045.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 布刀主 <anchor xml:id="app0910180403"/> 若 <anchor xml:id="app0910180403e"/> 玉命
                       <anchor xml:id="app0910180404"/> 神 <anchor xml:id="app0910180404e"/> 社 </cell>
@@ -7908,7 +7908,7 @@
                   </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00046.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00046.tif/full/full/0/default.jpg"
                     /> 表門神社 </cell>
                 </row>
                 <row>
@@ -8020,7 +8020,7 @@
             </app>
             <p ana="項" corresp="engishiki_v9_en.xml#item09102102 engishiki_v9_ja.xml#item09102102" xml:id="item09102102">
               <seg rendition="#indent"> 荏原郡二座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00047.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00047.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"><anchor xml:id="app0910210201"/> 薭田 <anchor xml:id="app0910210201e"/> 神社 </cell>
@@ -8140,7 +8140,7 @@
             </p>
             <p ana="項" corresp="engishiki_v9_en.xml#item09102108 engishiki_v9_ja.xml#item09102108" xml:id="item09102108">
               <seg rendition="#indent"> 埼玉郡四座〈並小、〉 </seg>
-              <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00048.tif/full/full/0/default.jpg"/>
+              <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00048.tif/full/full/0/default.jpg"/>
               <table>
                 <row>
                   <cell rendition="#width300"> 前玉神 <anchor xml:id="app0910210801"/> 社 <anchor xml:id="app0910210801e"/> 二座 </cell>
@@ -8281,7 +8281,7 @@
               <rdg wit="#土本 #京博本"/>
               <note> 小　土本・京博本無し、永本・九本・吉本あり。 </note>
             </app>
-            <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00049.tif/full/full/0/default.jpg"/>
+            <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00049.tif/full/full/0/default.jpg"/>
             <p ana="項" corresp="engishiki_v9_en.xml#item09102115 engishiki_v9_ja.xml#item09102115" xml:id="item09102115">
               <table rendition="#indent">
                 <row>
@@ -8415,7 +8415,7 @@
                   <cell rendition="#width300"> 望 <anchor xml:id="app0910230501"/> 陀 <anchor xml:id="app0910230501e"/> 郡一座〈小、〉 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"><pb
-                      facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00050.tif/full/full/0/default.jpg"
+                      facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00050.tif/full/full/0/default.jpg"
                     /> 飫富神社 </cell>
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"/>
@@ -8558,7 +8558,7 @@
               <note> 𧍑　土本「𧊭」、永本・九本・吉本「𧍑」、京博本「𧈿」。 </note>
             </app>
           </div>
-          <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00051.tif/full/full/0/default.jpg"/>
+          <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00051.tif/full/full/0/default.jpg"/>
           <div ana="神名上" corresp="engishiki_v9_en.xml#article091025 engishiki_v9_ja.xml#article091025" n="9.25" type="条"
             xml:id="article091025">
             <head ana="常陸国"/>
@@ -8694,7 +8694,7 @@
                   <cell rendition="#width50"/>
                   <cell rendition="#width300"/>
                 </row>
-                <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00052.tif/full/full/0/default.jpg"/>
+                <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00052.tif/full/full/0/default.jpg"/>
                 <row>
                   <cell rendition="#width300"> 藤内神社 </cell>
                   <cell rendition="#width50"/>
@@ -8866,7 +8866,7 @@
             <note> 朝臣　永本無し、吉本「朝」。土本・京博本あり。 </note>
           </app>
         </div>
-        <pb facs="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00053.tif/full/full/0/default.jpg"/>
+        <pb facs="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00053.tif/full/full/0/default.jpg"/>
         <div type="奥書" xml:id="shahonokugaki09">
           <p xml:id="shahonokugaki0901"><anchor xml:id="app0998880101"/> 此上下両巻、蒙勅命、仰嫡孫兼満終書写之功、致校合畢、 <lb/>
             <seg rendition="#indent"> 文亀三年十二月廿六日 </seg>
@@ -8892,168 +8892,168 @@
       </div>
     </body>
   </text>
-  <facsimile source="https://khirin-a.rekihaku.ac.jp/iiif/rekihaku/H-743-74-9/manifest.json">
+  <facsimile source="https://iiif.rekihaku.ac.jp/api/manifests/shiryo/H-743-74-9">
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4060" xml:id="page4060">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00001.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00001.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4061" xml:id="page4061">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00002.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00002.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4062" xml:id="page4062">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00003.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00003.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4063" xml:id="page4063">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00004.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00004.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4064" xml:id="page4064">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00005.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00005.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4065" xml:id="page4065">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00006.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00006.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4066" xml:id="page4066">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00007.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00007.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4067" xml:id="page4067">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00008.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00008.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4068" xml:id="page4068">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00009.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00009.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4069" xml:id="page4069">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00010.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00010.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4070" xml:id="page4070">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00011.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00011.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4071" xml:id="page4071">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00012.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00012.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4072" xml:id="page4072">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00013.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00013.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4073" xml:id="page4073">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00014.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00014.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4074" xml:id="page4074">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00015.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00015.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4075" xml:id="page4075">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00016.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00016.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4076" xml:id="page4076">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00017.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00017.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4077" xml:id="page4077">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00018.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00018.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4078" xml:id="page4078">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00019.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00019.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4079" xml:id="page4079">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00020.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00020.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4080" xml:id="page4080">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00021.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00021.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4081" xml:id="page4081">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00022.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00022.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4082" xml:id="page4082">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00023.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00023.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4083" xml:id="page4083">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00024.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00024.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4084" xml:id="page4084">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00025.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00025.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4085" xml:id="page4085">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00026.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00026.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4086" xml:id="page4086">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00027.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00027.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4087" xml:id="page4087">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00028.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00028.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4088" xml:id="page4088">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00029.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00029.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4089" xml:id="page4089">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00030.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00030.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4090" xml:id="page4090">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00031.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00031.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4091" xml:id="page4091">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00032.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00032.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4092" xml:id="page4092">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00033.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00033.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4093" xml:id="page4093">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00034.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00034.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4094" xml:id="page4094">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00035.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00035.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4095" xml:id="page4095">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00036.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00036.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4096" xml:id="page4096">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00037.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00037.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4097" xml:id="page4097">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00038.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00038.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4098" xml:id="page4098">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00039.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00039.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4099" xml:id="page4099">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00040.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00040.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4100" xml:id="page4100">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00041.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00041.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4101" xml:id="page4101">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00042.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00042.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4102" xml:id="page4102">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00043.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00043.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4103" xml:id="page4103">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00044.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00044.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4104" xml:id="page4104">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00045.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00045.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4105" xml:id="page4105">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00046.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00046.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4106" xml:id="page4106">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00047.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00047.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4107" xml:id="page4107">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00048.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00048.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4108" xml:id="page4108">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00049.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00049.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4109" xml:id="page4109">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00050.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00050.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4110" xml:id="page4110">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00051.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00051.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4111" xml:id="page4111">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00052.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00052.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4112" xml:id="page4112">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00053.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00053.tif/full/full/0/default.jpg"/>
     </surface>
     <surface source="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9/page4113" xml:id="page4113">
-      <graphic url="https://khirin-a.rekihaku.ac.jp/iiif/2/engishiki%2FH-743-74-9%2F00054.tif/full/full/0/default.jpg"/>
+      <graphic url="https://iiif.rekihaku.ac.jp/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-9/00054.tif/full/full/0/default.jpg"/>
     </surface>
   </facsimile>
 </TEI>


### PR DESCRIPTION
## 概要

旧 `khirin-a.rekihaku.ac.jp` (IIIF v2) から館内新システム `iiif.rekihaku.ac.jp` (IIIF v3) への移行に伴い、`TEI編集用/` の全19ファイルのIIIF URLを新システム向けに更新しました。旧 khirin-a は移行完了後に閉鎖予定です。

## 変更内容

| 対象 | 旧URL | 新URL | 件数 |
|---|---|---|---|
| 画像 (`<graphic url>` / `<pb facs>`) | `…/iiif/2/engishiki%2FH-743-74-N%2FNNNNN.tif/full/full/0/default.jpg` | `…/fcgi-bin/iipsrv.fcgi?IIIF=engishiki/H-743-74-N/NNNNN.tif/full/full/0/default.jpg` | 1,284 |
| manifest (`<facsimile source>`) | `…/iiif/rekihaku/H-743-74-N/manifest.json` | `…/api/manifests/shiryo/H-743-74-N` | 18 |

- 新URLはいずれも **HTTP 200** を確認。
- 全19ファイルの **well-formed性** を確認済み。
- URL以外の本文・タグ構造は無変更（1,302行の増減すべてがURL行）。

## 本PRで対応していないこと（別途対応予定）

- **`<surface source>` の `pageXXXX` URI（666件）は温存**しました。新システムには canvas URI 体系（`…/manifest/shiryo/H-743-74-N/canvas/pM`）があり揃える価値はありますが、canvas番号が「TIFF番号」ではなく「manifest内順序」のため、後述の欠落2ページが復旧してmanifestが再生成されると H-743-74-7・H-743-74-8 の canvas 採番が変わります。焼き込みは復旧後に行うのが安全なため別PRとします。なお `xml:id="pageXXXX"` は内部参照ゼロのため表示には影響しません。

## 前提・関連事項

- 本移行は **欠落2ページのリンク切れ解消を前提**としています。検証時点で以下2枚の画像実体が画像サーバー上に存在せず（info.json が HTTP 404）、新manifestからも除外されています。画像復旧後に表示される想定で、他ページと同様に新URLへ置換済みです。
  - `H-743-74-7 / 00005.tif`
  - `H-743-74-8 / 00020.tif`（Slackで既報の破損コマ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)